### PR TITLE
feat: initial mutator skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ members = [
     "third_party/move/tools/move-coverage",
     "third_party/move/tools/move-disassembler",
     "third_party/move/tools/move-explain",
+    "third_party/move/tools/move-mutator",
     "third_party/move/tools/move-package",
     "third_party/move/tools/move-resource-viewer",
     "third_party/move/tools/move-unit-test",
@@ -692,6 +693,7 @@ move-ir-types = { path = "third_party/move/move-ir/types" }
 move-ir-compiler = { path = "third_party/move/move-ir-compiler" }
 move-bytecode-source-map = { path = "third_party/move/move-ir-compiler/move-bytecode-source-map" }
 move-model = { path = "third_party/move/move-model" }
+move-mutator = { path = "third_party/move/tools/move-mutator" }
 move-package = { path = "third_party/move/tools/move-package" }
 move-prover = { path = "third_party/move/move-prover" }
 move-prover-boogie-backend = { path = "third_party/move/move-prover/boogie-backend" }

--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "move-mutator"
+version = "0.1.0"
+authors = ["Eiger <hello@eiger.co>"]
+
+description = "Move mutation tool"
+
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.3", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.5"

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -1,0 +1,1 @@
+# move-mutator

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -1,3 +1,4 @@
+use clap::{Arg, Command};
 use serde::{Deserialize, Serialize};
 
 /// Move mutator options
@@ -16,6 +17,47 @@ impl Default for Options {
     }
 }
 
+impl Options {
+    /// Creates Options struct from command line arguments.
+    pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
+        let cli = Command::new("mutate")
+            .version("0.1.0")
+            .about("The Move Mutator")
+            .author("Eiger Team")
+            .arg(
+                Arg::new("sources")
+                    .num_args(1..)
+                    .value_name("PATH_TO_SOURCE_FILE")
+                    .help("the source files to mutate"),
+            )
+            .after_help("See `move-mutator/doc` and `README.md` for documentation.");
+
+        // Parse the arguments. This will abort the program on parsing errors and print help.
+        // It will also accept options like --help.
+        let matches = cli.get_matches_from(args);
+
+        // Initialize options.
+        let get_vec = |s: &str| -> Vec<String> {
+            match matches.get_many::<String>(s) {
+                Some(vs) => vs.map(|v| v.to_string()).collect(),
+                _ => vec![],
+            }
+        };
+
+        let mut options = Options::default();
+
+        if matches
+            .get_many::<String>("sources")
+            .unwrap_or_default()
+            .len()
+            > 0
+        {
+            options.move_sources = get_vec("sources");
+        }
+
+        Ok(options)
+    }
+}
 
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -18,6 +18,16 @@ impl Default for Options {
 }
 
 impl Options {
+    /// Creates options from toml configuration source.
+    pub fn create_from_toml(toml_source: &str) -> anyhow::Result<Options> {
+        Ok(toml::from_str(toml_source)?)
+    }
+
+    /// Creates options from toml configuration file.
+    pub fn create_from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
+        Self::create_from_toml(&std::fs::read_to_string(toml_file)?)
+    }
+
     /// Creates Options struct from command line arguments.
     pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
         let cli = Command::new("mutate")

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -18,13 +18,13 @@ impl Default for Options {
 }
 
 impl Options {
-    /// Creates options from toml configuration source.
-    pub fn create_from_toml(toml_source: &str) -> anyhow::Result<Options> {
+    /// Creates options from the TOML configuration source.
+    pub fn from_toml(toml_source: &str) -> anyhow::Result<Options> {
         Ok(toml::from_str(toml_source)?)
     }
 
-    /// Creates options from toml configuration file.
-    pub fn create_from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
+    /// Creates options from the TOML configuration file.
+    pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
         Self::create_from_toml(&std::fs::read_to_string(toml_file)?)
     }
 

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+/// Move mutator options
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Options {
+    /// The paths to the Move sources.
+    pub move_sources: Vec<String>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            move_sources: vec![],
+        }
+    }
+}
+
+
+/// Runs the Move mutator tool.
+/// Entry point for the Move mutator tool both for the CLI and the Rust API.
+pub fn run_move_mutator(options: Options) -> anyhow::Result<()> {
+    println!(
+        "Executed move-mutator with the following options: {:?}",
+        options
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This PR contains initial files for the Move mutator.
There is only one Move option supported - source files to mutate. In fact, these files will be optional when the whole Move package is passed from the upper layers. For the POC, that option can be used to mutate single files within the package directory.
For now, the Move mutator prints only information that has been executed along with printing additional arguments.