### PR TITLE
[move-mutator] Move CLI integration

### DIFF
--- a/third_party/move/tools/move-cli/Cargo.toml
+++ b/third_party/move/tools/move-cli/Cargo.toml
@@ -42,6 +42,7 @@ move-docgen = { path = "../../move-prover/move-docgen" }
 move-errmapgen = { path = "../../move-prover/move-errmapgen" }
 move-ir-types = { path = "../../move-ir/types" }
 move-model = { path = "../../move-model" }
+move-mutator = { path = "../move-mutator" }
 move-package = { path = "../move-package" }
 move-prover = { path = "../../move-prover" }
 move-resource-viewer = { path = "../move-resource-viewer" }

--- a/third_party/move/tools/move-cli/src/base/mod.rs
+++ b/third_party/move/tools/move-cli/src/base/mod.rs
@@ -8,6 +8,7 @@ pub mod docgen;
 pub mod errmap;
 pub mod movey_login;
 pub mod movey_upload;
+pub mod mutate;
 pub mod new;
 pub mod prove;
 pub mod test;

--- a/third_party/move/tools/move-cli/src/base/mutate.rs
+++ b/third_party/move/tools/move-cli/src/base/mutate.rs
@@ -1,0 +1,39 @@
+use clap::*;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+/// Move mutator-specific options.
+#[derive(Parser, Debug)]
+pub enum MutatorOptions {
+    // Pass through unknown commands to the mutator Clap parser
+    #[clap(
+        external_subcommand,
+        takes_value(true),
+        multiple_values(true),
+        multiple_occurrences(true)
+    )]
+    Options(Vec<String>),
+}
+
+/// Mutate the Move files or package
+#[derive(Parser)]
+#[clap(name = "mutate")]
+pub struct Mutate {
+    /// Any options passed to the move-mutator
+    #[clap(subcommand)]
+    pub options: Option<MutatorOptions>,
+}
+
+impl Mutate {
+    pub fn execute(self, _path: Option<PathBuf>, _config: BuildConfig) -> anyhow::Result<()> {
+        let Self { options } = self;
+
+        let opts = match options {
+            Some(MutatorOptions::Options(opts)) => opts,
+            _ => vec![],
+        };
+
+        let options = move_mutator::Options::create_from_args(&opts)?;
+        move_mutator::run_move_mutator(options)
+    }
+}

--- a/third_party/move/tools/move-cli/src/lib.rs
+++ b/third_party/move/tools/move-cli/src/lib.rs
@@ -4,7 +4,7 @@
 
 use base::{
     build::Build, coverage::Coverage, disassemble::Disassemble, docgen::Docgen, errmap::Errmap,
-    movey_login::MoveyLogin, movey_upload::MoveyUpload, new::New, prove::Prove, test::Test,
+    movey_login::MoveyLogin, movey_upload::MoveyUpload, mutate::Mutate, new::New, prove::Prove, test::Test,
 };
 use move_package::BuildConfig;
 
@@ -68,6 +68,7 @@ pub enum Command {
     Docgen(Docgen),
     Errmap(Errmap),
     MoveyUpload(MoveyUpload),
+    Mutate(Mutate),
     New(New),
     Prove(Prove),
     Test(Test),
@@ -102,6 +103,7 @@ pub fn run_cli(
         Command::Docgen(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Errmap(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::MoveyUpload(c) => c.execute(move_args.package_path),
+        Command::Mutate(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::New(c) => c.execute_with_defaults(move_args.package_path),
         Command::Prove(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Test(c) => c.execute(

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -25,7 +25,7 @@ impl Options {
 
     /// Creates options from the TOML configuration file.
     pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
-        Self::create_from_toml(&std::fs::read_to_string(toml_file)?)
+        Self::from_toml(&std::fs::read_to_string(toml_file)?)
     }
 
     /// Creates Options struct from command line arguments.


### PR DESCRIPTION
Move CLI now recognizes `mutate` subcommand and calls mutator entry point passing received arguments.