### PR TITLE
[move-mutator] Aptos CLI integration - move mutate subcommand

### DIFF
--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -73,6 +73,7 @@ move-core-types = { workspace = true }
 move-coverage = { workspace = true }
 move-disassembler = { workspace = true }
 move-ir-types = { workspace = true }
+move-mutator = { workspace = true }
 move-package = { workspace = true }
 move-symbol-pool = { workspace = true }
 move-unit-test = { workspace = true, features = [ "debugging" ] }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -111,6 +111,8 @@ pub enum CliError {
     SimulationError(String),
     #[error("Coverage failed with status: {0}")]
     CoverageError(String),
+    #[error("Move mutator failed: {0}")]
+    MoveMutatorError(String),
 }
 
 impl CliError {
@@ -125,6 +127,7 @@ impl CliError {
             CliError::IO(_, _) => "IO",
             CliError::MoveCompilationError(_) => "MoveCompilationError",
             CliError::MoveTestError => "MoveTestError",
+            CliError::MoveMutatorError(_) => "MoveMutatorError",
             CliError::MoveProverError(_) => "MoveProverError",
             CliError::UnableToParse(_, _) => "UnableToParse",
             CliError::UnableToReadFile(_, _) => "UnableToReadFile",

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -85,6 +85,7 @@ pub enum MoveTool {
     Download(DownloadPackage),
     Init(InitPackage),
     List(ListPackage),
+    Mutate(MutatePackage),
     Prove(ProvePackage),
     Publish(PublishPackage),
     Run(RunFunction),
@@ -112,6 +113,7 @@ impl MoveTool {
             MoveTool::Download(tool) => tool.execute_serialized().await,
             MoveTool::Init(tool) => tool.execute_serialized_success().await,
             MoveTool::List(tool) => tool.execute_serialized().await,
+            MoveTool::Mutate(tool) => tool.execute_serialized().await,
             MoveTool::Prove(tool) => tool.execute_serialized().await,
             MoveTool::Publish(tool) => tool.execute_serialized().await,
             MoveTool::Run(tool) => tool.execute_serialized().await,
@@ -505,6 +507,46 @@ impl CliCommand<&'static str> for TestPackage {
         match result {
             UnitTestResult::Success => Ok("Success"),
             UnitTestResult::Failure => Err(CliError::MoveTestError),
+        }
+    }
+}
+
+/// Mutate a Move package
+#[derive(Parser)]
+pub struct MutatePackage {
+    #[clap(flatten)]
+    move_options: MovePackageDir,
+
+    #[clap(flatten)]
+    mutator_options: MutatorOptions,
+}
+
+#[derive(Parser)]
+pub struct MutatorOptions {
+    #[clap(long, short)]
+    pub move_sources: Vec<String>,
+}
+
+#[async_trait]
+impl CliCommand<&'static str> for MutatePackage {
+    fn command_name(&self) -> &'static str {
+        "MutatePackage"
+    }
+
+    async fn execute(self) -> CliTypedResult<&'static str> {
+        let MutatePackage {
+            move_options: _,
+            mutator_options,
+        } = self;
+
+        let result = move_mutator::run_move_mutator(move_mutator::Options {
+            move_sources: mutator_options.move_sources,
+        })
+        .map_err(|err| CliError::UnexpectedError(err.to_string()));
+
+        match result {
+            Ok(_) => Ok("Success"),
+            Err(e) => Err(CliError::MoveMutatorError(format!("{:#}", e))),
         }
     }
 }


### PR DESCRIPTION
Integration of `move mutate` subcommand which is accessible from Aptos CLI crate.
