### PR TITLE
[move-mutator] applying mutations and saving generated mutants

### DIFF
--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -28,7 +28,7 @@ or
 ./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
 ```
 
-The output will be generated under `mutants_output` directory.
+The output will be generated under the `mutants_output` directory.
 
 To generate mutants for all files within a test project run:
 ```bash

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -1,1 +1,85 @@
 # move-mutator
+
+Please build the whole repository first. In the `aptos-core` directory, run:
+```bash
+cargo build
+```
+
+Then build also the `move-cli` tool:
+```bash
+cargo build -p move-cli
+```
+
+Check if tool is working properly by running its tests:
+```bash
+cargo test -p move-mutator
+```
+
+## Usage
+
+To check if it works, run the following command:
+```bash
+./target/debug/move mutate sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+```
+
+or
+
+```bash
+./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+```
+
+Output will be generated under `mutants_output` directory.
+
+To generate mutants for all files within a test project run:
+```bash
+./target/debug/move mutate sources third_party/move/tools/move-mutator/tests/move-assets/simple/
+```
+or appropriately for `aptos`:
+```bash
+./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/
+```
+
+Running the above command (`aptos` one) will generate mutants for all files within the `simple` test project and should generate following output:
+```
+./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/
+Executed move-mutator with the following options: Options { move_sources: ["third_party/move/tools/move-mutator/tests/move-assets/simple/sources/"] } 
+ config: BuildConfig { dev_mode: false, test_mode: true, generate_docs: false, generate_abis: false, generate_move_model: false, full_model_generation: false, install_dir: None, force_recompilation: false, additional_named_addresses: {}, architecture: None, fetch_deps_only: false, skip_fetch_latest_git_deps: false, compiler_config: CompilerConfig { bytecode_version: None, known_attributes: {"bytecode_instruction", "deprecated", "event", "expected_failure", "legacy_entry_fun", "native_interface", "resource_group", "resource_group_member", "test", "test_only", "verify_only", "view"}, skip_attribute_checks: false, compiler_version: None } } 
+ package path: "/home/test/Projects/aptos-core"
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_0.move
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_1.move
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_2.move
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_3.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_4.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_5.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_6.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_7.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_8.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_9.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_10.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_11.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_12.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_13.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_14.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_15.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_16.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_17.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_18.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_19.move
+Mutant: BinaryOperator(&, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 357, index stop: 358) written to mutants_output/Operators_20.move
+Mutant: BinaryOperator(&, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 357, index stop: 358) written to mutants_output/Operators_21.move
+Mutant: BinaryOperator(|, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 412, index stop: 413) written to mutants_output/Operators_22.move
+Mutant: BinaryOperator(|, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 412, index stop: 413) written to mutants_output/Operators_23.move
+Mutant: BinaryOperator(^, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 468, index stop: 469) written to mutants_output/Operators_24.move
+Mutant: BinaryOperator(^, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 468, index stop: 469) written to mutants_output/Operators_25.move
+Mutant: BinaryOperator(<<, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 523, index stop: 525) written to mutants_output/Operators_26.move
+Mutant: BinaryOperator(>>, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 579, index stop: 581) written to mutants_output/Operators_27.move
+Mutant: UnaryOperator(!, location: file hash: 2adb714d41fdc23364c90e2fd21f9807a887ffd59343df63f9dfedde3fc62233, index start: 72, index stop: 73) written to mutants_output/Negation_0.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_0.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_1.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_2.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_3.move
+{
+  "Result": "Success"
+}
+
+```

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -10,7 +10,7 @@ Then build also the `move-cli` tool:
 cargo build -p move-cli
 ```
 
-Check if tool is working properly by running its tests:
+Check if the tool is working properly by running its tests:
 ```bash
 cargo test -p move-mutator
 ```
@@ -28,7 +28,7 @@ or
 ./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
 ```
 
-Output will be generated under `mutants_output` directory.
+The output will be generated under `mutants_output` directory.
 
 To generate mutants for all files within a test project run:
 ```bash

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -6,7 +6,9 @@ mod mutate;
 mod operator;
 
 mod mutant;
+
 use crate::compiler::generate_ast;
+use std::path::Path;
 
 use move_package::BuildConfig;
 use std::path::PathBuf;
@@ -23,13 +25,29 @@ pub fn run_move_mutator(
         options, config, package_path
     );
 
-    let (_files, ast) = generate_ast(options.move_sources, config, package_path)?;
+    let (files, ast) = generate_ast(options.move_sources, config, package_path)?;
 
     let mutants = mutate::mutate(ast)?;
 
-    println!("Mutants:");
-    for mutant in mutants {
-        println!("{}", mutant);
+    let _ = std::fs::remove_dir_all("mutants_output");
+    std::fs::create_dir("mutants_output")?;
+
+    for (hash, file) in files {
+        let (filename, source) = file;
+
+        let path = Path::new(filename.as_str());
+        let file_name = path.file_stem().unwrap().to_str().unwrap();
+
+        let mut i = 0;
+        for mutant in mutants.iter().filter(|m| m.get_file_hash() == hash) {
+            let mutated_sources = mutant.apply(&source);
+            for source in mutated_sources {
+                let mut_path = format!("mutants_output/{}_{}.move", file_name, i);
+                println!("{} written to {}", mutant, &mut_path);
+                std::fs::write(mut_path, source)?;
+                i += 1;
+            }
+        }
     }
 
     Ok(())

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -13,6 +13,8 @@ use std::path::Path;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
+const OUTPUT_DIR: &str = "mutants_output";
+
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.
 pub fn run_move_mutator(
@@ -29,12 +31,10 @@ pub fn run_move_mutator(
 
     let mutants = mutate::mutate(ast)?;
 
-    let _ = std::fs::remove_dir_all("mutants_output");
-    std::fs::create_dir("mutants_output")?;
+    let _ = std::fs::remove_dir_all(OUTPUT_DIR);
+    std::fs::create_dir(OUTPUT_DIR)?;
 
-    for (hash, file) in files {
-        let (filename, source) = file;
-
+    for (hash, (filename, source)) in files {
         let path = Path::new(filename.as_str());
         let file_name = path.file_stem().unwrap().to_str().unwrap();
 

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,4 +1,5 @@
-use move_compiler::parser::ast::{BinOp, UnaryOp};
+use move_command_line_common::files::FileHash;
+use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp};
 use std::fmt;
 
 /// The mutation operator to apply.
@@ -6,6 +7,64 @@ use std::fmt;
 pub enum MutationOperator {
     BinaryOperator(BinOp),
     UnaryOperator(UnaryOp),
+}
+
+impl MutationOperator {
+    /// Applies the mutation operator to the given source code.
+    /// Returns a vector of mutated source code.
+    pub fn apply(&self, source: &str) -> Vec<String> {
+        match self {
+            MutationOperator::BinaryOperator(bin_op) => {
+                let start = bin_op.loc.start() as usize;
+                let end = bin_op.loc.end() as usize;
+                let op = &source[start..end];
+
+                let ops: Vec<&str> = match bin_op.value {
+                    BinOp_::Add | BinOp_::Sub | BinOp_::Mul | BinOp_::Div | BinOp_::Mod => {
+                        vec!["+", "-", "*", "/", "%"]
+                    },
+                    BinOp_::BitOr | BinOp_::BitAnd | BinOp_::Xor => {
+                        vec!["|", "&", "^"]
+                    },
+                    BinOp_::Shl | BinOp_::Shr => {
+                        vec!["<<", ">>"]
+                    },
+                    _ => vec![],
+                };
+
+                ops.into_iter()
+                    .filter(|v| op != *v)
+                    .map(|op| {
+                        let mut mutated_source = source.to_string();
+                        mutated_source.replace_range(start..end, op);
+                        mutated_source
+                    })
+                    .collect()
+            },
+            MutationOperator::UnaryOperator(unary_op) => {
+                let start = unary_op.loc.start() as usize;
+                let end = unary_op.loc.end() as usize;
+
+                // For unary operator mutations, we only need to replace the operator with a space (to ensure the same file length)
+                vec![" "]
+                    .into_iter()
+                    .map(|op| {
+                        let mut mutated_source = source.to_string();
+                        mutated_source.replace_range(start..end, op);
+                        mutated_source
+                    })
+                    .collect()
+            },
+        }
+    }
+
+    /// Returns the file hash of the file that this mutation operator is in.
+    pub fn get_file_hash(&self) -> FileHash {
+        match self {
+            MutationOperator::BinaryOperator(bin_op) => bin_op.loc.file_hash(),
+            MutationOperator::UnaryOperator(unary_op) => unary_op.loc.file_hash(),
+        }
+    }
 }
 
 impl fmt::Display for MutationOperator {
@@ -28,5 +87,50 @@ impl fmt::Display for MutationOperator {
                 unary_op.loc.end()
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_command_line_common::files::FileHash;
+    use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp, UnaryOp_};
+    use move_ir_types::location::Loc;
+
+    #[test]
+    fn test_apply_binary_operator() {
+        let loc = Loc::new(FileHash::new(""), 0, 1);
+        let bin_op = BinOp {
+            value: BinOp_::Mul,
+            loc,
+        };
+        let operator = MutationOperator::BinaryOperator(bin_op);
+        let source = "*";
+        let expected = vec!["+", "-", "/", "%"];
+        assert_eq!(operator.apply(source), expected);
+    }
+
+    #[test]
+    fn test_apply_unary_operator() {
+        let loc = Loc::new(FileHash::new(""), 0, 1);
+        let unary_op = UnaryOp {
+            value: UnaryOp_::Not,
+            loc,
+        };
+        let operator = MutationOperator::UnaryOperator(unary_op);
+        let source = "!";
+        let expected = vec![" "];
+        assert_eq!(operator.apply(source), expected);
+    }
+
+    #[test]
+    fn test_get_file_hash() {
+        let loc = Loc::new(FileHash::new(""), 0, 0);
+        let bin_op = BinOp {
+            value: BinOp_::Add,
+            loc,
+        };
+        let operator = MutationOperator::BinaryOperator(bin_op);
+        assert_eq!(operator.get_file_hash(), FileHash::new(""));
     }
 }


### PR DESCRIPTION
This commit introduces applying mutations to the original source files and writing changed files to disk.

Mutants are saved for now in the current directory under the `mutant_output` directory. This will change in the future.
