### PR TITLE
[move-mutator] go deeper and search for exprs in all elements

### DIFF
--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -3,7 +3,10 @@ use move_compiler::parser::ast::{FunctionBody_, SequenceItem_};
 
 use crate::mutant::Mutant;
 use crate::operator::MutationOperator;
-use move_compiler::parser::ast::{Definition::Module, ModuleMember};
+use move_compiler::parser::ast::{
+    Definition::{Address, Module, Script},
+    ModuleMember,
+};
 
 /// Traverses the AST, identifies places where mutation operators can be applied
 /// and returns a list of mutants.
@@ -11,9 +14,14 @@ pub fn mutate(ast: parser::ast::Program) -> anyhow::Result<Vec<Mutant>> {
     let mutants = ast
         .source_definitions
         .into_iter()
-        .filter_map(|package| match package.def {
-            Module(module) => Some(traverse_module(module)),
-            _ => None,
+        .flat_map(|package| match package.def {
+            Address(addr) => addr
+                .modules
+                .into_iter()
+                .map(traverse_module)
+                .collect::<Vec<Result<Vec<_>, _>>>(),
+            Module(module) => vec![traverse_module(module)],
+            Script(script) => vec![traverse_function(script.function)],
         })
         .collect::<Result<Vec<_>, _>>()?
         .concat();
@@ -27,6 +35,7 @@ fn traverse_module(module: parser::ast::ModuleDefinition) -> anyhow::Result<Vec<
         .into_iter()
         .filter_map(|member| match member {
             ModuleMember::Function(func) => Some(traverse_function(func)),
+            ModuleMember::Constant(constant) => Some(parse_expression(constant.value)),
             _ => None,
         })
         .collect::<Result<Vec<_>, _>>()?
@@ -37,20 +46,22 @@ fn traverse_module(module: parser::ast::ModuleDefinition) -> anyhow::Result<Vec<
 
 fn traverse_function(function: parser::ast::Function) -> anyhow::Result<Vec<Mutant>> {
     match function.body.value {
-        FunctionBody_::Defined(elem) => {
-            let (_, seq, _, exp) = elem;
-            let mut mutants = seq
-                .into_iter()
-                .map(traverse_sequence_item)
-                .collect::<Result<Vec<_>, _>>()?
-                .concat();
-
-            // exp represents the return expression so we need to remember to parse it
-            mutants.extend(parse_expression(exp.unwrap())?);
-            Ok(mutants)
-        },
+        FunctionBody_::Defined(elem) => traverse_sequence(elem),
         _ => Ok(vec![]),
     }
+}
+
+fn traverse_sequence(elem: parser::ast::Sequence) -> anyhow::Result<Vec<Mutant>> {
+    let (_, seq, _, exp) = elem;
+    let mut mutants = seq
+        .into_iter()
+        .map(traverse_sequence_item)
+        .collect::<Result<Vec<_>, _>>()?
+        .concat();
+
+    // exp represents the return expression so we need to remember to parse it
+    mutants.extend(parse_expression(exp.unwrap())?);
+    Ok(mutants)
 }
 
 fn traverse_sequence_item(seq_item: parser::ast::SequenceItem) -> anyhow::Result<Vec<Mutant>> {
@@ -82,6 +93,69 @@ fn parse_expression(exp: parser::ast::Exp) -> anyhow::Result<Vec<Mutant>> {
 
             Ok(mutants)
         },
+        parser::ast::Exp_::Assign(exp1, exp2) | parser::ast::Exp_::While(exp1, exp2) => {
+            let mut mutants = parse_expression(*exp1)?;
+            mutants.extend(parse_expression(*exp2)?);
+            Ok(mutants)
+        },
+        parser::ast::Exp_::Block(seq) => traverse_sequence(seq),
+        parser::ast::Exp_::Pack(_, _, exps) => {
+            let mut mutants = vec![];
+            for (_, exp) in exps {
+                mutants.extend(parse_expression(exp)?);
+            }
+            Ok(mutants)
+        },
+        parser::ast::Exp_::Call(_, _, _, exps) | parser::ast::Exp_::Vector(_, _, exps) => Ok(exps
+            .value
+            .into_iter()
+            .map(parse_expression)
+            .collect::<Result<Vec<_>, _>>()?
+            .concat()),
+        parser::ast::Exp_::ExpList(exps) => Ok(exps
+            .into_iter()
+            .map(parse_expression)
+            .collect::<Result<Vec<_>, _>>()?
+            .concat()),
+        parser::ast::Exp_::IfElse(exp1, exp2, exp3) => {
+            let mut mutants = parse_expression(*exp1)?;
+            mutants.extend(parse_expression(*exp2)?);
+            if let Some(exp3) = exp3 {
+                mutants.extend(parse_expression(*exp3)?);
+            }
+            Ok(mutants)
+        },
+        parser::ast::Exp_::Quant(_, _, vexp, lexp, exp) => {
+            let mut mutants = vec![];
+            for exp in vexp {
+                let muts = exp
+                    .into_iter()
+                    .map(parse_expression)
+                    .collect::<Result<Vec<_>, _>>()?
+                    .concat();
+                mutants.extend(muts);
+            }
+            if let Some(lexp) = lexp {
+                mutants.extend(parse_expression(*lexp)?);
+            }
+            mutants.extend(parse_expression(*exp)?);
+            Ok(mutants)
+        },
+        parser::ast::Exp_::Return(exp) => {
+            if let Some(exp) = exp {
+                parse_expression(*exp)
+            } else {
+                Ok(vec![])
+            }
+        },
+        parser::ast::Exp_::Abort(exp)
+        | parser::ast::Exp_::Annotate(exp, _)
+        | parser::ast::Exp_::Borrow(_, exp)
+        | parser::ast::Exp_::Cast(exp, _)
+        | parser::ast::Exp_::Dereference(exp)
+        | parser::ast::Exp_::Dot(exp, _)
+        | parser::ast::Exp_::Loop(exp)
+        | parser::ast::Exp_::Lambda(_, exp) => parse_expression(*exp),
         _ => Ok(vec![]),
     }
 }

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -60,7 +60,10 @@ fn traverse_sequence(elem: parser::ast::Sequence) -> anyhow::Result<Vec<Mutant>>
         .concat();
 
     // exp represents the return expression so we need to remember to parse it
-    mutants.extend(parse_expression(exp.unwrap())?);
+    if let Some(exp) = *exp {
+        mutants.extend(parse_expression(exp)?);
+    }
+
     Ok(mutants)
 }
 
@@ -141,13 +144,7 @@ fn parse_expression(exp: parser::ast::Exp) -> anyhow::Result<Vec<Mutant>> {
             mutants.extend(parse_expression(*exp)?);
             Ok(mutants)
         },
-        parser::ast::Exp_::Return(exp) => {
-            if let Some(exp) = exp {
-                parse_expression(*exp)
-            } else {
-                Ok(vec![])
-            }
-        },
+        parser::ast::Exp_::Return(Some(exp)) => parse_expression(*exp),
         parser::ast::Exp_::Abort(exp)
         | parser::ast::Exp_::Annotate(exp, _)
         | parser::ast::Exp_::Borrow(_, exp)


### PR DESCRIPTION
Go deeper inside the AST tree and search for expressions that may be part of the other expressions or language instructions. This includes also searching inside the address spaces and scripts.

