### PR TITLE
[move-verifier] Move Mutator proof of concept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ members = [
     "third_party/move/tools/move-coverage",
     "third_party/move/tools/move-disassembler",
     "third_party/move/tools/move-explain",
+    "third_party/move/tools/move-mutator",
     "third_party/move/tools/move-package",
     "third_party/move/tools/move-resource-viewer",
     "third_party/move/tools/move-unit-test",
@@ -693,6 +694,7 @@ move-ir-types = { path = "third_party/move/move-ir/types" }
 move-ir-compiler = { path = "third_party/move/move-ir-compiler" }
 move-bytecode-source-map = { path = "third_party/move/move-ir-compiler/move-bytecode-source-map" }
 move-model = { path = "third_party/move/move-model" }
+move-mutator = { path = "third_party/move/tools/move-mutator" }
 move-package = { path = "third_party/move/tools/move-package" }
 move-prover = { path = "third_party/move/move-prover" }
 move-prover-boogie-backend = { path = "third_party/move/move-prover/boogie-backend" }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -73,6 +73,7 @@ move-core-types = { workspace = true }
 move-coverage = { workspace = true }
 move-disassembler = { workspace = true }
 move-ir-types = { workspace = true }
+move-mutator = { workspace = true }
 move-package = { workspace = true }
 move-symbol-pool = { workspace = true }
 move-unit-test = { workspace = true, features = [ "debugging" ] }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -111,6 +111,8 @@ pub enum CliError {
     SimulationError(String),
     #[error("Coverage failed with status: {0}")]
     CoverageError(String),
+    #[error("Move mutator failed: {0}")]
+    MoveMutatorError(String),
 }
 
 impl CliError {
@@ -125,6 +127,7 @@ impl CliError {
             CliError::IO(_, _) => "IO",
             CliError::MoveCompilationError(_) => "MoveCompilationError",
             CliError::MoveTestError => "MoveTestError",
+            CliError::MoveMutatorError(_) => "MoveMutatorError",
             CliError::MoveProverError(_) => "MoveProverError",
             CliError::UnableToParse(_, _) => "UnableToParse",
             CliError::UnableToReadFile(_, _) => "UnableToReadFile",

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -514,25 +514,30 @@ impl CliCommand<&'static str> for TestPackage {
 /// Mutate a Move package
 #[derive(Parser)]
 pub struct MutatePackage {
+    /// Options for parsing and compiling a move package dir (used by the Move compiler)
     #[clap(flatten)]
     move_options: MovePackageDir,
-
+    /// Options specific for the mutator tool
     #[clap(flatten)]
     mutator_options: MutatorOptions,
 }
 
+/// Move mutator tool options
 #[derive(Parser)]
 pub struct MutatorOptions {
+    /// Move source files to mutate (paths)
     #[clap(long, short)]
     pub move_sources: Vec<String>,
 }
 
 #[async_trait]
 impl CliCommand<&'static str> for MutatePackage {
+    /// Returns the name of the command used in the CLI.
     fn command_name(&self) -> &'static str {
         "MutatePackage"
     }
 
+    /// Executes the mutate command and generates mutants with the provided parameters.
     async fn execute(self) -> CliTypedResult<&'static str> {
         let MutatePackage {
             move_options: _,

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -539,9 +539,32 @@ impl CliCommand<&'static str> for MutatePackage {
             mutator_options,
         } = self;
 
-        let result = move_mutator::run_move_mutator(move_mutator::Options {
-            move_sources: mutator_options.move_sources,
-        })
+        let known_attributes = extended_checks::get_all_attribute_names();
+        let config = BuildConfig {
+            dev_mode: self.move_options.dev,
+            additional_named_addresses: self.move_options.named_addresses(),
+            test_mode: true,
+            full_model_generation: self.move_options.check_test_code,
+            install_dir: self.move_options.output_dir.clone(),
+            skip_fetch_latest_git_deps: self.move_options.skip_fetch_latest_git_deps,
+            compiler_config: CompilerConfig {
+                known_attributes: known_attributes.clone(),
+                skip_attribute_checks: self.move_options.skip_attribute_checks,
+                compiler_version: self.move_options.compiler_version,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let path = self.move_options.get_package_path()?;
+
+        let result = move_mutator::run_move_mutator(
+            move_mutator::cli::Options {
+                move_sources: mutator_options.move_sources,
+            },
+            config,
+            path,
+        )
         .map_err(|err| CliError::UnexpectedError(err.to_string()));
 
         match result {

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -85,6 +85,7 @@ pub enum MoveTool {
     Download(DownloadPackage),
     Init(InitPackage),
     List(ListPackage),
+    Mutate(MutatePackage),
     Prove(ProvePackage),
     Publish(PublishPackage),
     Run(RunFunction),
@@ -112,6 +113,7 @@ impl MoveTool {
             MoveTool::Download(tool) => tool.execute_serialized().await,
             MoveTool::Init(tool) => tool.execute_serialized_success().await,
             MoveTool::List(tool) => tool.execute_serialized().await,
+            MoveTool::Mutate(tool) => tool.execute_serialized().await,
             MoveTool::Prove(tool) => tool.execute_serialized().await,
             MoveTool::Publish(tool) => tool.execute_serialized().await,
             MoveTool::Run(tool) => tool.execute_serialized().await,
@@ -505,6 +507,46 @@ impl CliCommand<&'static str> for TestPackage {
         match result {
             UnitTestResult::Success => Ok("Success"),
             UnitTestResult::Failure => Err(CliError::MoveTestError),
+        }
+    }
+}
+
+/// Mutate a Move package
+#[derive(Parser)]
+pub struct MutatePackage {
+    #[clap(flatten)]
+    move_options: MovePackageDir,
+
+    #[clap(flatten)]
+    mutator_options: MutatorOptions,
+}
+
+#[derive(Parser)]
+pub struct MutatorOptions {
+    #[clap(long, short)]
+    pub move_sources: Vec<String>,
+}
+
+#[async_trait]
+impl CliCommand<&'static str> for MutatePackage {
+    fn command_name(&self) -> &'static str {
+        "MutatePackage"
+    }
+
+    async fn execute(self) -> CliTypedResult<&'static str> {
+        let MutatePackage {
+            move_options: _,
+            mutator_options,
+        } = self;
+
+        let result = move_mutator::run_move_mutator(move_mutator::Options {
+            move_sources: mutator_options.move_sources,
+        })
+        .map_err(|err| CliError::UnexpectedError(err.to_string()));
+
+        match result {
+            Ok(_) => Ok("Success"),
+            Err(e) => Err(CliError::MoveMutatorError(format!("{:#}", e))),
         }
     }
 }

--- a/third_party/move/tools/move-cli/Cargo.toml
+++ b/third_party/move/tools/move-cli/Cargo.toml
@@ -42,6 +42,7 @@ move-docgen = { path = "../../move-prover/move-docgen" }
 move-errmapgen = { path = "../../move-prover/move-errmapgen" }
 move-ir-types = { path = "../../move-ir/types" }
 move-model = { path = "../../move-model" }
+move-mutator = { path = "../move-mutator" }
 move-package = { path = "../move-package" }
 move-prover = { path = "../../move-prover" }
 move-resource-viewer = { path = "../move-resource-viewer" }

--- a/third_party/move/tools/move-cli/src/base/mod.rs
+++ b/third_party/move/tools/move-cli/src/base/mod.rs
@@ -8,6 +8,7 @@ pub mod docgen;
 pub mod errmap;
 pub mod movey_login;
 pub mod movey_upload;
+pub mod mutate;
 pub mod new;
 pub mod prove;
 pub mod test;

--- a/third_party/move/tools/move-cli/src/base/mutate.rs
+++ b/third_party/move/tools/move-cli/src/base/mutate.rs
@@ -1,0 +1,39 @@
+use clap::*;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+/// Move mutator-specific options.
+#[derive(Parser, Debug)]
+pub enum MutatorOptions {
+    // Pass through unknown commands to the mutator Clap parser
+    #[clap(
+        external_subcommand,
+        takes_value(true),
+        multiple_values(true),
+        multiple_occurrences(true)
+    )]
+    Options(Vec<String>),
+}
+
+/// Mutate the Move files or package
+#[derive(Parser)]
+#[clap(name = "mutate")]
+pub struct Mutate {
+    /// Any options passed to the move-mutator
+    #[clap(subcommand)]
+    pub options: Option<MutatorOptions>,
+}
+
+impl Mutate {
+    pub fn execute(self, _path: Option<PathBuf>, _config: BuildConfig) -> anyhow::Result<()> {
+        let Self { options } = self;
+
+        let opts = match options {
+            Some(MutatorOptions::Options(opts)) => opts,
+            _ => vec![],
+        };
+
+        let options = move_mutator::Options::create_from_args(&opts)?;
+        move_mutator::run_move_mutator(options)
+    }
+}

--- a/third_party/move/tools/move-cli/src/base/mutate.rs
+++ b/third_party/move/tools/move-cli/src/base/mutate.rs
@@ -25,7 +25,9 @@ pub struct Mutate {
 }
 
 impl Mutate {
-    pub fn execute(self, _path: Option<PathBuf>, _config: BuildConfig) -> anyhow::Result<()> {
+    pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
+        let path = path.unwrap_or_else(|| PathBuf::from("."));
+
         let Self { options } = self;
 
         let opts = match options {
@@ -33,7 +35,7 @@ impl Mutate {
             _ => vec![],
         };
 
-        let options = move_mutator::Options::create_from_args(&opts)?;
-        move_mutator::run_move_mutator(options)
+        let options = move_mutator::cli::Options::create_from_args(&opts)?;
+        move_mutator::run_move_mutator(options, config, path)
     }
 }

--- a/third_party/move/tools/move-cli/src/base/mutate.rs
+++ b/third_party/move/tools/move-cli/src/base/mutate.rs
@@ -25,6 +25,9 @@ pub struct Mutate {
 }
 
 impl Mutate {
+    /// Executes the mutate command which produces mutants from the Move files or package using
+    /// the provided configuration.
+    /// If no path is provided, the current directory is used.
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
         let path = path.unwrap_or_else(|| PathBuf::from("."));
 

--- a/third_party/move/tools/move-cli/src/lib.rs
+++ b/third_party/move/tools/move-cli/src/lib.rs
@@ -4,7 +4,7 @@
 
 use base::{
     build::Build, coverage::Coverage, disassemble::Disassemble, docgen::Docgen, errmap::Errmap,
-    movey_login::MoveyLogin, movey_upload::MoveyUpload, new::New, prove::Prove, test::Test,
+    movey_login::MoveyLogin, movey_upload::MoveyUpload, mutate::Mutate, new::New, prove::Prove, test::Test,
 };
 use move_package::BuildConfig;
 
@@ -68,6 +68,7 @@ pub enum Command {
     Docgen(Docgen),
     Errmap(Errmap),
     MoveyUpload(MoveyUpload),
+    Mutate(Mutate),
     New(New),
     Prove(Prove),
     Test(Test),
@@ -102,6 +103,7 @@ pub fn run_cli(
         Command::Docgen(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Errmap(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::MoveyUpload(c) => c.execute(move_args.package_path),
+        Command::Mutate(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::New(c) => c.execute_with_defaults(move_args.package_path),
         Command::Prove(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Test(c) => c.execute(

--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "move-mutator"
+version = "0.1.0"
+authors = ["Eiger <hello@eiger.co>"]
+
+description = "Move mutation tool"
+
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.3", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.5"

--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -18,4 +18,7 @@ clap = { version = "4.3", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 
+move-command-line-common = { path = "../../move-command-line-common" }
+move-compiler = { path = "../../move-compiler" }
+move-ir-types = { path = "../../move-ir/types" }
 move-package = { path = "../move-package" }

--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -17,3 +17,5 @@ anyhow = "1.0"
 clap = { version = "4.3", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
+
+move-package = { path = "../move-package" }

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -1,0 +1,1 @@
+# move-mutator

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -28,7 +28,7 @@ or
 ./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
 ```
 
-The output will be generated under `mutants_output` directory.
+The output will be generated under the `mutants_output` directory.
 
 To generate mutants for all files within a test project run:
 ```bash

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -1,1 +1,85 @@
 # move-mutator
+
+Please build the whole repository first. In the `aptos-core` directory, run:
+```bash
+cargo build
+```
+
+Then build also the `move-cli` tool:
+```bash
+cargo build -p move-cli
+```
+
+Check if tool is working properly by running its tests:
+```bash
+cargo test -p move-mutator
+```
+
+## Usage
+
+To check if it works, run the following command:
+```bash
+./target/debug/move mutate sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+```
+
+or
+
+```bash
+./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+```
+
+Output will be generated under `mutants_output` directory.
+
+To generate mutants for all files within a test project run:
+```bash
+./target/debug/move mutate sources third_party/move/tools/move-mutator/tests/move-assets/simple/
+```
+or appropriately for `aptos`:
+```bash
+./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/
+```
+
+Running the above command (`aptos` one) will generate mutants for all files within the `simple` test project and should generate following output:
+```
+./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/
+Executed move-mutator with the following options: Options { move_sources: ["third_party/move/tools/move-mutator/tests/move-assets/simple/sources/"] } 
+ config: BuildConfig { dev_mode: false, test_mode: true, generate_docs: false, generate_abis: false, generate_move_model: false, full_model_generation: false, install_dir: None, force_recompilation: false, additional_named_addresses: {}, architecture: None, fetch_deps_only: false, skip_fetch_latest_git_deps: false, compiler_config: CompilerConfig { bytecode_version: None, known_attributes: {"bytecode_instruction", "deprecated", "event", "expected_failure", "legacy_entry_fun", "native_interface", "resource_group", "resource_group_member", "test", "test_only", "verify_only", "view"}, skip_attribute_checks: false, compiler_version: None } } 
+ package path: "/home/test/Projects/aptos-core"
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_0.move
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_1.move
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_2.move
+Mutant: BinaryOperator(+, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 77, index stop: 78) written to mutants_output/Operators_3.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_4.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_5.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_6.move
+Mutant: BinaryOperator(-, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 133, index stop: 134) written to mutants_output/Operators_7.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_8.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_9.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_10.move
+Mutant: BinaryOperator(*, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 189, index stop: 190) written to mutants_output/Operators_11.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_12.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_13.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_14.move
+Mutant: BinaryOperator(%, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 245, index stop: 246) written to mutants_output/Operators_15.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_16.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_17.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_18.move
+Mutant: BinaryOperator(/, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 301, index stop: 302) written to mutants_output/Operators_19.move
+Mutant: BinaryOperator(&, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 357, index stop: 358) written to mutants_output/Operators_20.move
+Mutant: BinaryOperator(&, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 357, index stop: 358) written to mutants_output/Operators_21.move
+Mutant: BinaryOperator(|, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 412, index stop: 413) written to mutants_output/Operators_22.move
+Mutant: BinaryOperator(|, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 412, index stop: 413) written to mutants_output/Operators_23.move
+Mutant: BinaryOperator(^, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 468, index stop: 469) written to mutants_output/Operators_24.move
+Mutant: BinaryOperator(^, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 468, index stop: 469) written to mutants_output/Operators_25.move
+Mutant: BinaryOperator(<<, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 523, index stop: 525) written to mutants_output/Operators_26.move
+Mutant: BinaryOperator(>>, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 579, index stop: 581) written to mutants_output/Operators_27.move
+Mutant: UnaryOperator(!, location: file hash: 2adb714d41fdc23364c90e2fd21f9807a887ffd59343df63f9dfedde3fc62233, index start: 72, index stop: 73) written to mutants_output/Negation_0.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_0.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_1.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_2.move
+Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_3.move
+{
+  "Result": "Success"
+}
+
+```

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -10,7 +10,7 @@ Then build also the `move-cli` tool:
 cargo build -p move-cli
 ```
 
-Check if tool is working properly by running its tests:
+Check if the tool is working properly by running its tests:
 ```bash
 cargo test -p move-mutator
 ```
@@ -28,7 +28,7 @@ or
 ./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
 ```
 
-Output will be generated under `mutants_output` directory.
+The output will be generated under `mutants_output` directory.
 
 To generate mutants for all files within a test project run:
 ```bash

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -30,7 +30,15 @@ or
 
 The output will be generated under the `mutants_output` directory.
 
-To generate mutants for all files within a test project run:
+There are also good tests in the Move Prover repository that can be used to test the tool. To run them just use:
+```
+./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/arithm.move
+./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/bitwise_operators.move
+./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/nonlinear_arithm.move
+./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/shift.move
+```
+
+To generate mutants for all files within a test project run (there are `Sum.move`, `Operators.move`, `Negation.move` and `StillSimple.move`):
 ```bash
 ./target/debug/move mutate sources third_party/move/tools/move-mutator/tests/move-assets/simple/
 ```
@@ -74,6 +82,70 @@ Mutant: BinaryOperator(^, location: file hash: 871072646343dc04b16c8b19009982460
 Mutant: BinaryOperator(<<, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 523, index stop: 525) written to mutants_output/Operators_26.move
 Mutant: BinaryOperator(>>, location: file hash: 871072646343dc04b16c8b19009982460f2afbc55f14d2f1c2710e741d9a0ce1, index start: 579, index stop: 581) written to mutants_output/Operators_27.move
 Mutant: UnaryOperator(!, location: file hash: 2adb714d41fdc23364c90e2fd21f9807a887ffd59343df63f9dfedde3fc62233, index start: 72, index stop: 73) written to mutants_output/Negation_0.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 93, index stop: 94) written to mutants_output/StillSimple_0.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 93, index stop: 94) written to mutants_output/StillSimple_1.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 93, index stop: 94) written to mutants_output/StillSimple_2.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 93, index stop: 94) written to mutants_output/StillSimple_3.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 111, index stop: 112) written to mutants_output/StillSimple_4.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 111, index stop: 112) written to mutants_output/StillSimple_5.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 111, index stop: 112) written to mutants_output/StillSimple_6.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 111, index stop: 112) written to mutants_output/StillSimple_7.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 302, index stop: 303) written to mutants_output/StillSimple_8.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 302, index stop: 303) written to mutants_output/StillSimple_9.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 302, index stop: 303) written to mutants_output/StillSimple_10.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 302, index stop: 303) written to mutants_output/StillSimple_11.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 444, index stop: 445) written to mutants_output/StillSimple_12.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 444, index stop: 445) written to mutants_output/StillSimple_13.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 444, index stop: 445) written to mutants_output/StillSimple_14.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 444, index stop: 445) written to mutants_output/StillSimple_15.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 429, index stop: 430) written to mutants_output/StillSimple_16.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 429, index stop: 430) written to mutants_output/StillSimple_17.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 429, index stop: 430) written to mutants_output/StillSimple_18.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 429, index stop: 430) written to mutants_output/StillSimple_19.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 613, index stop: 614) written to mutants_output/StillSimple_20.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 613, index stop: 614) written to mutants_output/StillSimple_21.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 613, index stop: 614) written to mutants_output/StillSimple_22.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 613, index stop: 614) written to mutants_output/StillSimple_23.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 705, index stop: 706) written to mutants_output/StillSimple_24.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 705, index stop: 706) written to mutants_output/StillSimple_25.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 705, index stop: 706) written to mutants_output/StillSimple_26.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 705, index stop: 706) written to mutants_output/StillSimple_27.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 839, index stop: 840) written to mutants_output/StillSimple_28.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 839, index stop: 840) written to mutants_output/StillSimple_29.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 839, index stop: 840) written to mutants_output/StillSimple_30.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 839, index stop: 840) written to mutants_output/StillSimple_31.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 857, index stop: 858) written to mutants_output/StillSimple_32.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 857, index stop: 858) written to mutants_output/StillSimple_33.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 857, index stop: 858) written to mutants_output/StillSimple_34.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 857, index stop: 858) written to mutants_output/StillSimple_35.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 852, index stop: 853) written to mutants_output/StillSimple_36.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 852, index stop: 853) written to mutants_output/StillSimple_37.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 852, index stop: 853) written to mutants_output/StillSimple_38.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 852, index stop: 853) written to mutants_output/StillSimple_39.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 937, index stop: 938) written to mutants_output/StillSimple_40.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 937, index stop: 938) written to mutants_output/StillSimple_41.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 937, index stop: 938) written to mutants_output/StillSimple_42.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 937, index stop: 938) written to mutants_output/StillSimple_43.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 948, index stop: 949) written to mutants_output/StillSimple_44.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 948, index stop: 949) written to mutants_output/StillSimple_45.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 948, index stop: 949) written to mutants_output/StillSimple_46.move
+Mutant: BinaryOperator(+, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 948, index stop: 949) written to mutants_output/StillSimple_47.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 944, index stop: 945) written to mutants_output/StillSimple_48.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 944, index stop: 945) written to mutants_output/StillSimple_49.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 944, index stop: 945) written to mutants_output/StillSimple_50.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 944, index stop: 945) written to mutants_output/StillSimple_51.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 952, index stop: 953) written to mutants_output/StillSimple_52.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 952, index stop: 953) written to mutants_output/StillSimple_53.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 952, index stop: 953) written to mutants_output/StillSimple_54.move
+Mutant: BinaryOperator(*, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 952, index stop: 953) written to mutants_output/StillSimple_55.move
+Mutant: BinaryOperator(/, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 954, index stop: 955) written to mutants_output/StillSimple_56.move
+Mutant: BinaryOperator(/, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 954, index stop: 955) written to mutants_output/StillSimple_57.move
+Mutant: BinaryOperator(/, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 954, index stop: 955) written to mutants_output/StillSimple_58.move
+Mutant: BinaryOperator(/, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 954, index stop: 955) written to mutants_output/StillSimple_59.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 941, index stop: 942) written to mutants_output/StillSimple_60.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 941, index stop: 942) written to mutants_output/StillSimple_61.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 941, index stop: 942) written to mutants_output/StillSimple_62.move
+Mutant: BinaryOperator(-, location: file hash: b63e76f992c022b7d34f479a1b1fe5bb744ec27afa38aa4fe22d081897a91fa0, index start: 941, index stop: 942) written to mutants_output/StillSimple_63.move
 Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_0.move
 Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_1.move
 Mutant: BinaryOperator(+, location: file hash: cf19f52b0c8c5facfd7cc8f34dbd487a4ea8719e613bbab2f5abb24d51bc355e, index start: 86, index stop: 87) written to mutants_output/Sum_2.move

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -1,0 +1,251 @@
+# Move mutator tool design
+
+## Overview
+
+The Move mutator is a tool that mutates Move source code. It is used to help test the robustness of Move analyzers and verifiers by generating different code versions (mutants).
+
+## Prototype
+This chapter will be deleted upon implementing the Move mutator tool.
+
+The Prototype implements only binary operator replacement (arithmetic, bitwise and shifts) and unary operator replacement. Command line options mainly handle source file paths (single or package).
+
+Mutants are currently stored in the `mutants_output` directory, and there is no way to change it. Mutants are just saved in a flat structure (no subdirectories). Each mutant filename consists of the original source filename with the next index appended.
+
+The report is generated on screen and lists all generated mutants (which mutation operator was used, location in the original source file, and mutant output). It's not possible to create the report in a file.
+
+Not supported:
+- configuration file,
+- generating reports,
+- nicely formatted output,
+- mutant files output structure,
+- other mutation operators than binary and unary operator replacement.
+
+### What's missing in the Move ecosystem
+
+To create a prototype, we've used existing Move tools and libraries. We've produced a working prototype, so generally, there are no significant gaps in the Move ecosystem. It's sufficient for the mutant generation.
+
+However, some things could be improved. The most important is the specification testing tool as a separate tool. Currently, the Move Prover is used to test specifications, but it can't be used efficiently to test generated mutants.
+
+Move Prover demands to be run inside the Move package. We can't pass to Prover just mutants directory, as it will be unable to find the dependencies. Moreover, it's not also possible to simply copy the mutants inside the existing structure (or create a structure and put the mutants there) as Prover can't handle dozens of files which contain the same modules, the same function names, etc.
+
+There is a need for a tool that will be able to run the Prover, passing it the mutants one by one and then collecting the results. Running the Prover in parallel should be possible, as it will speed up the process. The tool should also be able to handle the Prover output and generate a report. So, that report would be a separate report from the mutation tool.
+
+##  Architecture
+
+The Move mutator tool is composed of the modules that are described below. Each module is responsible for a different application part. Such an approach allows for easy extension and modification. Modules are grouped into logical layers, separating and isolating the application parts.
+
+The Move mutator tool is the heart of the specification verification process, as depending on its quality, the verification process will be more or less efficient. The Move mutator tool is designed to be easily extensible, so it's possible to add new mutation operators, new mutation categories, etc.
+
+The mutation process is separated from the other parts of the verification process. It makes it possible to use mutator output (mutants) to verify the specification's quality using Move Prover and check the completeness and quality of test suites. Users can also use mutants in their own applications and scripts.
+
+### Presentation layer
+
+In this project, the presentation layer execution modules (displaying and fetching data from/to the user) are moved to the `aptos` and `move` command line interfaces.
+
+Mutator itself provides a CLI module, which is integrated into the existing Aptos repository - it handles options that the mutator tool can use.
+
+There are two types of output that the Move mutator tool generates:
+- the actual mutants (source code files)
+- the report (JSON and text file)
+
+The actual mutants are stored in the output directory (default: `mutants_output/mutants`). The directory structure is the same as in the original source code. The mutant filename consists of the original source filename with mutation information (operator) and the mutant index appended.
+
+The report is generated in the output directory. It's possible to create the report in JSON or text format. The JSON format is used to pass the report to other tools. The text format is used by the user to display the report on the screen.
+
+JSON report format sample:
+
+```json
+{
+    "mutants": [
+        {
+            "id": 1,
+            "operator": "binary_operator_replacement",
+            "category": "arithmetic",
+            "location": {
+                "file": "path/to/file",
+                "start_index": 1,
+                "stop_index": 1
+            },
+            "original": "original expression",
+            "mutant": "mutated expression"
+        }
+    ]
+}
+```
+
+### Service layer
+
+It contains an API module that exposes function calls to other modules (internal or external).
+
+It is mainly used to expose the `run_move_mutator` function, which is the entry point to the Move mutator tool. It takes the configuration file path as an argument and returns the list of mutants.
+
+### Main logic layer
+
+This layer is responsible for the main logic of the application. The main application layer with crucial components used to generate mutants:
+
+The functions in the `mutate.rs` are responsible for traversing the Abstract Syntax Tree (AST) of the Move source code and searching for places where potential mutation operators can be applied. It has been AST from the `parser` Move compiler module used, but it may not be a big change to traverse other trees (unless the locations pointed by the appropriate structs will match the source code). The `parser` tree has been used because it's the closest module to the original source file and represents the exact structure of the source file. It makes it much easier to replace expressions with the mutated ones.
+The idea behind that search is as follows: there is a `mutate` function which is the entry point. It takes the AST of a Move program as input and returns a list of mutants (not yet generated). It does this by iterating over the source definitions in the AST and calling the appropriate function to traverse each definition based on its type (Address, Module, or Script). There are several functions to go through different types of AST nodes. 
+
+The main parsing function is the `parse_expression`. It checks the type of the expression and marks that place as the appropriate for the mutation operator to be applied (e.g., binary or unary expressions). Sub-expressions are parsed recursively.
+
+When a new place for mutation is found, new mutant is created. The mutation operator is passed as an argument containing the appropriate AST node. As each node has its own location (`Spanned` structure with `Loc`) it's possible to pass the node without any additional overhead.
+This process continues recursively until all nodes in the AST have been visited and all possible mutants have been generated. The mutate function then returns the list of mutants.
+
+Mutations are applied during output generation. Each potential mutation place is run through the `apply` function, which applies the mutation operator to sources. That produces an output file which can be saved.
+
+The `apply` function is the one that handles mutation categories that can exist inside the mutation operators. For example, the binary operator replacement mutation operator has categories like arithmetic, bitwise, and shifts. When the `apply` function is called, it checks if the mutation operator has categories. If so, it chooses an appropriate category based on the expression. ALL mutations within the category are applied.
+
+The above means that the operator tool can produce many mutants within one place in the source code for each mutation. Concrete operators or categories can be filtered using the configuration file described in the data layer section.
+
+Once generated, mutants can be checked to see if they are valid. It's possible to run the Move compiler to check if the mutant is valid, as some of the mutations can create mutants that cannot be compiled properly.
+
+The last module in the main logic layer filters the mutants and reduces the outcome.
+
+### Data layer
+
+This layer handles data sources - reading Move projects (source code) and configuration files. It also provides data to the other layers.
+
+The configuration file is a JSON file that contains the configuration of the Move mutator tool. It includes information on the project to mutate, mutation operators to use, mutation categories to use, and so on.
+
+Sample configuration file:
+```json
+{
+    "project": {
+        "path": "path/to/project",
+        "files": [
+            "path/to/file1",
+            "path/to/file2"
+        ]
+    },
+    "mutation": {
+        "operators": [
+            "binary_operator_replacement",
+            "unary_operator_replacement"
+        ],
+        "categories": [
+            "arithmetic",
+            "bitwise",
+            "shifts"
+        ]
+    }
+}
+```
+
+### Cross layer
+
+The layer is used to provide a common function set to other layers. None of their functions is exposed externally. Its crucial components are:
+- logging module - gathers logs from other internal components and allows them to be saved for further analysis (e.g., in case of an error).
+- IO support - various input/output functions (formatters) and helpers.
+- Move compiler API (`compiler.rs`) - various functions to handle Move compiler communication - the ability to compile source files and generate AST from specified files, etc.
+
+## Command line interface integration
+
+Move mutator can be integrated with any command line interface. To do so, CLI application needs to collect arguments and call the `run_move_mutator` function from the `move_mutator` crate.
+
+Currently, the Move mutator tool is integrated with the `move-cli` and `aptos` command line interfaces. There is introduced a new command: `mutate` which allows to pass the mutator arguments. Check README.md for more details.
+
+## Specification verification tool
+
+The Move mutator tool is designed to create mutants only. It does not perform the proving process as it is not the goal of the tool.
+
+The specification verification tool is a tool placed inside the `aptos` repository, which provides additional `aptos` subcommand - `spec-verify` which does the following:
+1. Takes arguments both for the Move Prover tool and for the Move mutator tool. It can also read the configuration from the JSON configuration file.
+2. Run the Move mutator tool (`mutate`) to generate mutants with the previously specified parameters.
+3. Run the Move Prover tool, passing the generated mutants one by one.
+4. Collect the results and generate a report.
+
+The report contains information about the generated mutants as well as the killed ones for each tested source file. All the intermediate results are saved in the configurable (default: `mutants_output`) directory.
+
+## Mutation operators
+
+Mutation operators can be divided into two groups. The first group is composed of mutation operators that, once replaced, do not change the length of the original program. That operator can be mixed inside on file to achieve more complex mutations. The second group is composed of mutation operators that, once replaced, change the length of the original program. That operator cannot be mixed inside one file, so each mutant has only one mutation of that kind. It should be possible to combine many non-changing file length mutation operators with one changing len mutation operator, but the latter needs to be applied as the last one. Such behaviour needs to be enabled explicitly in the configuration, as by default, it will generate only one mutation at once.
+
+The above behaviour can be discussed if it's really needed.
+
+The reason for introducing two groups of mutation operators is connected with the way the Move mutator tool works. It reads the source file(-s) once and then works on the original AST. If any previous mutation changes the original file, then it would demand reloading the modified source (as upon change, all current AST locations become outdated), parsing the AST and again for possible mutations. It would be very inefficient.
+
+The Move mutator tool implements the following mutation operators.
+
+### Binary operator replacement
+
+This mutation operator replaces binary operators with other binary operators. For example, the `+` operator can be replaced with the `-` operator.
+
+Operators are grouped into the following categories:
+- arithmetic operators: `+`, `-`, `*`, `/`, `%`
+- bitwise operators: `&`, `|`, `^`
+- shifts: `<<`, `>>`
+- comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- logical operators: `&&`, `||`
+
+Operators are replaced within the same category. For example, the `+` operator can be replaced with the `-` operator but not the `<<` operator.
+
+Binary operators are never removed, as it would produce invalid code.
+
+The operator tests the conditions in the specifications and test suites.
+
+It can be mixed with other non-changing file length mutation operators.
+
+### Unary operator replacement
+
+This mutation operator replaces unary operators with other unary operators. For example, the `!` operator can be replaced with the space. So, in fact, it removes the operator but without changing the file length.
+
+The operator tests the conditions in the specifications and test suites.
+
+Thanks to the fact that, the operator is replaced with space instead of just removing, it can be mixed with other non-changing file length mutation operators.
+
+### Type replacement
+
+This mutation operator replaces types with other types. For example, the `u8` type can be replaced with the `u64` type.
+
+It can't be mixed with other mutation operators as it may change the file length.
+
+### Literal replacement
+
+This mutation operator replaces literals with other literals. For example, the `0` literal can be replaced with the `1` literal or other random literal, `true` to `false`, etc.
+
+It's possible to choose the type of the literal to be replaced. For example, it's possible to replace only boolean literals.
+
+The operator tests the different conditions in the specifications (like invariants) and test suites.
+
+It can't be mixed with other mutation operators as it may change the file length.
+
+### Address replacement
+
+This mutation operator replaces addresses with other addresses. For example, the `0x1`/`@std` address can be replaced with the `0x000A` address or another random address.
+
+It can't be mixed with other mutation operators as it may change the file length.
+
+### Return value replacement
+
+This mutation operator replaces return values with other return values. For example, the concrete expressions can be replaced with concrete literals or other random literals.
+
+The operator tests the conditions in the test suites and, e.g. the `ensures` statement in specifications.
+
+It can't be mixed with other mutation operators as it may change the file length.
+
+### Break/continue replacement or deletion
+
+This mutation operator replaces or deletes break/continue statements with other break/continue statements.
+
+It can't be mixed with other mutation operators as it may change the file length.
+
+## Extending the Move mutator tool
+
+The Move mutator tool is designed to be easily extensible. It's possible to add new mutation operators, new mutation categories and so on. The following sections describe how to do it.
+
+### Adding a new mutation operator
+
+To add a new mutation operator, you need to:
+1. Add a new mutation operator to the `MutationOperator` enum in the `operator.rs` file.
+2. Implement mutation logic in the `apply` function in the `operator.rs` file.
+3. Update AST traversal code in the `mutate.rs` file - add or modify a place in the AST where the mutation operator should be applied.
+4. Add a test for the new mutation operator.
+
+### Adding a new mutation category
+
+Sometimes, it's helpful to group mutation operators into categories. For example, it's useful to group arithmetic operators together. It's possible to do it by adding a new mutation category.
+
+Categories exist only to group mutation operators. They are not used anywhere else. They reside in the `operator.rs` file inside the `apply` function. To add a new category, simply modify the existing operator, adding or excluding new groups based on the already present code (look at the `BinaryOperator`, `ops` vector).
+
+
+

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Move mutator is a tool that mutates Move source code. It is used to help test the robustness of Move analyzers and verifiers by generating different code versions (mutants).
+The Move mutator is a tool that mutates Move source code. It can be used to help test the robustness of Move specifications and unit tests by generating different code versions (mutants).
 
 ## Prototype
 This chapter will be deleted upon implementing the Move mutator tool.
@@ -144,7 +144,7 @@ Move mutator can be integrated with any command line interface. To do so, CLI ap
 
 Currently, the Move mutator tool is integrated with the `move-cli` and `aptos` command line interfaces. There is introduced a new command: `mutate` which allows to pass the mutator arguments. Check README.md for more details.
 
-## Specification verification tool
+## Specification testing tool
 
 The Move mutator tool is designed to create mutants only. It does not perform the proving process as it is not the goal of the tool.
 

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -158,11 +158,11 @@ The report contains information about the generated mutants as well as the kille
 
 ## Mutation operators
 
-Mutation operators can be divided into two groups. The first group is composed of mutation operators that, once replaced, do not change the length of the original program. That operator can be mixed inside on file to achieve more complex mutations. The second group is composed of mutation operators that, once replaced, change the length of the original program. That operator cannot be mixed inside one file, so each mutant has only one mutation of that kind. It should be possible to combine many non-changing file length mutation operators with one changing len mutation operator, but the latter needs to be applied as the last one. Such behaviour needs to be enabled explicitly in the configuration, as by default, it will generate only one mutation at once.
+Mutation operators can be applied alone or mixed with other ones. The decision is made based on the configuration file. The default behaviour is to use one mutation operator at a time (per file). It's worth noting that mixing operators within one file will significantly increase the number of generated mutants.
+
+The mutation tool reads the source file(-s) once and then works on the original AST. If any previous mutation changes the original file, it would demand reloading the modified source (as upon change, all current AST locations become outdated), parsing the AST and again for possible mutations. It would be very inefficient. Once mutation places are identified, mutants are generated in reversed order (based on localization) to avoid that. If operator mixing is allowed, they are applied only for non-overlapping expressions.
 
 The above behaviour can be discussed if it's really needed.
-
-The reason for introducing two groups of mutation operators is connected with the way the Move mutator tool works. It reads the source file(-s) once and then works on the original AST. If any previous mutation changes the original file, then it would demand reloading the modified source (as upon change, all current AST locations become outdated), parsing the AST and again for possible mutations. It would be very inefficient.
 
 The Move mutator tool implements the following mutation operators.
 
@@ -183,21 +183,17 @@ Binary operators are never removed, as it would produce invalid code.
 
 The operator tests the conditions in the specifications and test suites.
 
-It can be mixed with other non-changing file length mutation operators.
-
 ### Unary operator replacement
 
 This mutation operator replaces unary operators with other unary operators. For example, the `!` operator can be replaced with the space. So, in fact, it removes the operator but without changing the file length.
 
 The operator tests the conditions in the specifications and test suites.
 
-Thanks to the fact that, the operator is replaced with space instead of just removing, it can be mixed with other non-changing file length mutation operators.
+Thanks to the fact that, the operator is replaced with space instead of just removing.
 
 ### Type replacement
 
 This mutation operator replaces types with other types. For example, the `u8` type can be replaced with the `u64` type.
-
-It can't be mixed with other mutation operators as it may change the file length.
 
 ### Literal replacement
 
@@ -207,13 +203,9 @@ It's possible to choose the type of the literal to be replaced. For example, it'
 
 The operator tests the different conditions in the specifications (like invariants) and test suites.
 
-It can't be mixed with other mutation operators as it may change the file length.
-
 ### Address replacement
 
 This mutation operator replaces addresses with other addresses. For example, the `0x1`/`@std` address can be replaced with the `0x000A` address or another random address.
-
-It can't be mixed with other mutation operators as it may change the file length.
 
 ### Return value replacement
 
@@ -221,13 +213,9 @@ This mutation operator replaces return values with other return values. For exam
 
 The operator tests the conditions in the test suites and, e.g. the `ensures` statement in specifications.
 
-It can't be mixed with other mutation operators as it may change the file length.
-
 ### Break/continue replacement or deletion
 
 This mutation operator replaces or deletes break/continue statements with other break/continue statements.
-
-It can't be mixed with other mutation operators as it may change the file length.
 
 ## Extending the Move mutator tool
 

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -1,0 +1,108 @@
+use clap::{Arg, Command};
+use serde::{Deserialize, Serialize};
+
+/// Command line options for mutator
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Options {
+    /// The paths to the Move sources.
+    pub move_sources: Vec<String>,
+}
+
+impl Options {
+    /// Creates options from the TOML configuration source.
+    pub fn from_toml(toml_source: &str) -> anyhow::Result<Options> {
+        Ok(toml::from_str(toml_source)?)
+    }
+
+    /// Creates options from the TOML configuration file.
+    pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
+        Self::from_toml(&std::fs::read_to_string(toml_file)?)
+    }
+
+    /// Creates Options struct from command line arguments.
+    pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
+        let cli = Command::new("mutate")
+            .version("0.1.0")
+            .about("The Move Mutator")
+            .author("Eiger Team")
+            .arg(
+                Arg::new("sources")
+                    .num_args(1..)
+                    .value_name("PATH_TO_SOURCE_FILE")
+                    .help("the source files to mutate"),
+            )
+            .after_help("See `move-mutator/doc` and `README.md` for documentation.");
+
+        // Parse the arguments. This will abort the program on parsing errors and print help.
+        // It will also accept options like --help.
+        let matches = cli.get_matches_from(args);
+
+        // Initialize options.
+        let get_vec = |s: &str| -> Vec<String> {
+            match matches.get_many::<String>(s) {
+                Some(vs) => vs.map(|v| v.to_string()).collect(),
+                _ => vec![],
+            }
+        };
+
+        let mut options = Options::default();
+
+        if matches
+            .get_many::<String>("sources")
+            .unwrap_or_default()
+            .len()
+            > 0
+        {
+            options.move_sources = get_vec("sources");
+        }
+
+        Ok(options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+
+    #[test]
+    fn test_from_toml() {
+        let toml_str = r#"
+            move_sources = ["src/main.rs", "src/lib.rs"]
+        "#;
+
+        let options = Options::from_toml(toml_str).unwrap();
+        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
+    }
+
+    #[test]
+    fn test_from_toml_file() {
+        let toml_str = r#"
+            move_sources = ["src/main.rs", "src/lib.rs"]
+        "#;
+
+        let path = Path::new("test.toml");
+        let mut file = File::create(&path).unwrap();
+        file.write_all(toml_str.as_bytes()).unwrap();
+
+        let options = Options::from_toml_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
+
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_create_from_args() {
+        let args = vec![
+            String::from("mutate"),
+            String::from("src/main.rs"),
+            String::from("src/lib.rs"),
+        ];
+
+        let options = Options::create_from_args(&args).unwrap();
+        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
+    }
+}

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -16,14 +16,16 @@ pub fn generate_ast(
     config: BuildConfig,
     package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
-    let mut named_addr_map = BTreeMap::new();
-
-    for (name, addr) in config.additional_named_addresses {
-        named_addr_map.insert(
-            name,
-            NumericalAddress::new(addr.into_bytes(), NumberFormat::Decimal),
-        );
-    }
+    let named_addr_map = config
+        .additional_named_addresses
+        .into_iter()
+        .map(|(name, addr)| {
+            (
+                name,
+                NumericalAddress::new(addr.into_bytes(), NumberFormat::Decimal),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
 
     let out_dir = "mutator_build";
     let interface_files_dir = format!("{}/generated_interface_files", out_dir);

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -1,0 +1,50 @@
+use move_command_line_common::address::NumericalAddress;
+use move_command_line_common::parser::NumberFormat;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use move_compiler::diagnostics::FilesSourceText;
+use move_compiler::{
+    command_line::compiler::*, diagnostics::unwrap_or_report_diagnostics, shared::Flags,
+};
+use move_package::source_package::layout::SourcePackageLayout;
+use move_package::BuildConfig;
+
+/// Generate the AST from the Move sources.
+pub fn generate_ast(
+    source_files: Vec<String>,
+    config: BuildConfig,
+    package_path: PathBuf,
+) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
+    let mut named_addr_map = BTreeMap::new();
+
+    for (name, addr) in config.additional_named_addresses {
+        named_addr_map.insert(
+            name,
+            NumericalAddress::new(addr.into_bytes(), NumberFormat::Decimal),
+        );
+    }
+
+    let out_dir = "mutator_build";
+    let interface_files_dir = format!("{}/generated_interface_files", out_dir);
+    let flags = Flags::empty();
+
+    //TODO(asmie): check if root is not found (we cannot parse then Move.toml and get the address resolution)
+    // Maybe we should then allow only source files with numerical addresses
+    let _rooted_path = SourcePackageLayout::try_find_root(&package_path.canonicalize()?);
+
+    let (files, res) = Compiler::from_files(
+        source_files,
+        vec![],
+        named_addr_map,
+        flags,
+        &config.compiler_config.known_attributes,
+    )
+    .set_interface_files_dir(interface_files_dir)
+    .run::<PASS_PARSER>()?;
+
+    let (_, stepped) = unwrap_or_report_diagnostics(&files, res);
+    let (_, ast) = stepped.into_ast();
+
+    Ok((files, ast))
+}

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -11,6 +11,24 @@ use move_package::source_package::layout::SourcePackageLayout;
 use move_package::BuildConfig;
 
 /// Generate the AST from the Move sources.
+///
+/// Generation of the AST is done by the Move compiler. Move compiler is stepped compiler, which means that
+/// it is possible to get the intermediate results of the compilation. This function uses it to get the AST
+/// right after the parsing phase.
+///
+/// Generated AST contains all the information for all the Move files provided in the `source_files` vector.
+/// Compiler searches automatically for all the needed files (like manifest) and dependencies. In case of
+/// any error, that error is returned.
+///
+/// # Arguments
+///
+/// * `source_files` - vector of strings representing the Move source files paths.
+/// * `config` - contains the actual build configuration.
+/// * `package_path` - the path to the Move package.
+///
+/// # Returns
+///
+/// * `Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error>` - tuple of FilesSourceText and Program if successful, or an error if any error occurs.
 pub fn generate_ast(
     source_files: Vec<String>,
     config: BuildConfig,

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -1,3 +1,4 @@
+use clap::{Arg, Command};
 use serde::{Deserialize, Serialize};
 
 /// Move mutator options
@@ -16,6 +17,47 @@ impl Default for Options {
     }
 }
 
+impl Options {
+    /// Creates Options struct from command line arguments.
+    pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
+        let cli = Command::new("mutate")
+            .version("0.1.0")
+            .about("The Move Mutator")
+            .author("Eiger Team")
+            .arg(
+                Arg::new("sources")
+                    .num_args(1..)
+                    .value_name("PATH_TO_SOURCE_FILE")
+                    .help("the source files to mutate"),
+            )
+            .after_help("See `move-mutator/doc` and `README.md` for documentation.");
+
+        // Parse the arguments. This will abort the program on parsing errors and print help.
+        // It will also accept options like --help.
+        let matches = cli.get_matches_from(args);
+
+        // Initialize options.
+        let get_vec = |s: &str| -> Vec<String> {
+            match matches.get_many::<String>(s) {
+                Some(vs) => vs.map(|v| v.to_string()).collect(),
+                _ => vec![],
+            }
+        };
+
+        let mut options = Options::default();
+
+        if matches
+            .get_many::<String>("sources")
+            .unwrap_or_default()
+            .len()
+            > 0
+        {
+            options.move_sources = get_vec("sources");
+        }
+
+        Ok(options)
+    }
+}
 
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -6,7 +6,9 @@ mod mutate;
 mod operator;
 
 mod mutant;
+
 use crate::compiler::generate_ast;
+use std::path::Path;
 
 use move_package::BuildConfig;
 use std::path::PathBuf;
@@ -23,13 +25,29 @@ pub fn run_move_mutator(
         options, config, package_path
     );
 
-    let (_files, ast) = generate_ast(options.move_sources, config, package_path)?;
+    let (files, ast) = generate_ast(options.move_sources, config, package_path)?;
 
     let mutants = mutate::mutate(ast)?;
 
-    println!("Mutants:");
-    for mutant in mutants {
-        println!("{}", mutant);
+    let _ = std::fs::remove_dir_all("mutants_output");
+    std::fs::create_dir("mutants_output")?;
+
+    for (hash, file) in files {
+        let (filename, source) = file;
+
+        let path = Path::new(filename.as_str());
+        let file_name = path.file_stem().unwrap().to_str().unwrap();
+
+        let mut i = 0;
+        for mutant in mutants.iter().filter(|m| m.get_file_hash() == hash) {
+            let mutated_sources = mutant.apply(&source);
+            for source in mutated_sources {
+                let mut_path = format!("mutants_output/{}_{}.move", file_name, i);
+                println!("{} written to {}", mutant, &mut_path);
+                std::fs::write(mut_path, source)?;
+                i += 1;
+            }
+        }
     }
 
     Ok(())

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -18,6 +18,16 @@ impl Default for Options {
 }
 
 impl Options {
+    /// Creates options from toml configuration source.
+    pub fn create_from_toml(toml_source: &str) -> anyhow::Result<Options> {
+        Ok(toml::from_str(toml_source)?)
+    }
+
+    /// Creates options from toml configuration file.
+    pub fn create_from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
+        Self::create_from_toml(&std::fs::read_to_string(toml_file)?)
+    }
+
     /// Creates Options struct from command line arguments.
     pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
         let cli = Command::new("mutate")

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -1,81 +1,20 @@
-use clap::{Arg, Command};
-use serde::{Deserialize, Serialize};
+pub mod cli;
 
-/// Move mutator options
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct Options {
-    /// The paths to the Move sources.
-    pub move_sources: Vec<String>,
-}
-
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            move_sources: vec![],
-        }
-    }
-}
-
-impl Options {
-    /// Creates options from the TOML configuration source.
-    pub fn from_toml(toml_source: &str) -> anyhow::Result<Options> {
-        Ok(toml::from_str(toml_source)?)
-    }
-
-    /// Creates options from the TOML configuration file.
-    pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
-        Self::from_toml(&std::fs::read_to_string(toml_file)?)
-    }
-
-    /// Creates Options struct from command line arguments.
-    pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
-        let cli = Command::new("mutate")
-            .version("0.1.0")
-            .about("The Move Mutator")
-            .author("Eiger Team")
-            .arg(
-                Arg::new("sources")
-                    .num_args(1..)
-                    .value_name("PATH_TO_SOURCE_FILE")
-                    .help("the source files to mutate"),
-            )
-            .after_help("See `move-mutator/doc` and `README.md` for documentation.");
-
-        // Parse the arguments. This will abort the program on parsing errors and print help.
-        // It will also accept options like --help.
-        let matches = cli.get_matches_from(args);
-
-        // Initialize options.
-        let get_vec = |s: &str| -> Vec<String> {
-            match matches.get_many::<String>(s) {
-                Some(vs) => vs.map(|v| v.to_string()).collect(),
-                _ => vec![],
-            }
-        };
-
-        let mut options = Options::default();
-
-        if matches
-            .get_many::<String>("sources")
-            .unwrap_or_default()
-            .len()
-            > 0
-        {
-            options.move_sources = get_vec("sources");
-        }
-
-        Ok(options)
-    }
-}
+use move_package::BuildConfig;
+use std::path::PathBuf;
 
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.
-pub fn run_move_mutator(options: Options) -> anyhow::Result<()> {
+pub fn run_move_mutator(
+    options: cli::Options,
+    config: BuildConfig,
+    package_path: PathBuf,
+) -> anyhow::Result<()> {
     println!(
-        "Executed move-mutator with the following options: {:?}",
-        options
+        "Executed move-mutator with the following options: {:?} \n config: {:?} \n package path: {:?}",
+        options, config, package_path
     );
+
 
     Ok(())
 }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -13,6 +13,8 @@ use std::path::Path;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
+const OUTPUT_DIR: &str = "mutants_output";
+
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.
 pub fn run_move_mutator(
@@ -29,12 +31,10 @@ pub fn run_move_mutator(
 
     let mutants = mutate::mutate(ast)?;
 
-    let _ = std::fs::remove_dir_all("mutants_output");
-    std::fs::create_dir("mutants_output")?;
+    let _ = std::fs::remove_dir_all(OUTPUT_DIR);
+    std::fs::create_dir(OUTPUT_DIR)?;
 
-    for (hash, file) in files {
-        let (filename, source) = file;
-
+    for (hash, (filename, source)) in files {
         let path = Path::new(filename.as_str());
         let file_name = path.file_stem().unwrap().to_str().unwrap();
 

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod cli;
+mod compiler;
+
+use crate::compiler::generate_ast;
 
 use move_package::BuildConfig;
 use std::path::PathBuf;
@@ -15,6 +18,10 @@ pub fn run_move_mutator(
         options, config, package_path
     );
 
+    let (files, ast) = generate_ast(options.move_sources, config, package_path)?;
+
+    println!("Files: {:?}", files);
+    println!("AST: {:?}", ast);
 
     Ok(())
 }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -25,7 +25,7 @@ impl Options {
 
     /// Creates options from the TOML configuration file.
     pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
-        Self::create_from_toml(&std::fs::read_to_string(toml_file)?)
+        Self::from_toml(&std::fs::read_to_string(toml_file)?)
     }
 
     /// Creates Options struct from command line arguments.

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -18,13 +18,13 @@ impl Default for Options {
 }
 
 impl Options {
-    /// Creates options from toml configuration source.
-    pub fn create_from_toml(toml_source: &str) -> anyhow::Result<Options> {
+    /// Creates options from the TOML configuration source.
+    pub fn from_toml(toml_source: &str) -> anyhow::Result<Options> {
         Ok(toml::from_str(toml_source)?)
     }
 
-    /// Creates options from toml configuration file.
-    pub fn create_from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
+    /// Creates options from the TOML configuration file.
+    pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
         Self::create_from_toml(&std::fs::read_to_string(toml_file)?)
     }
 

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -1,6 +1,11 @@
 pub mod cli;
 mod compiler;
 
+mod mutate;
+
+mod operator;
+
+mod mutant;
 use crate::compiler::generate_ast;
 
 use move_package::BuildConfig;
@@ -18,10 +23,14 @@ pub fn run_move_mutator(
         options, config, package_path
     );
 
-    let (files, ast) = generate_ast(options.move_sources, config, package_path)?;
+    let (_files, ast) = generate_ast(options.move_sources, config, package_path)?;
 
-    println!("Files: {:?}", files);
-    println!("AST: {:?}", ast);
+    let mutants = mutate::mutate(ast)?;
+
+    println!("Mutants:");
+    for mutant in mutants {
+        println!("{}", mutant);
+    }
 
     Ok(())
 }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+/// Move mutator options
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Options {
+    /// The paths to the Move sources.
+    pub move_sources: Vec<String>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            move_sources: vec![],
+        }
+    }
+}
+
+
+/// Runs the Move mutator tool.
+/// Entry point for the Move mutator tool both for the CLI and the Rust API.
+pub fn run_move_mutator(options: Options) -> anyhow::Result<()> {
+    println!(
+        "Executed move-mutator with the following options: {:?}",
+        options
+    );
+
+    Ok(())
+}

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -20,7 +20,8 @@ impl Mutant {
         self.operator.get_file_hash()
     }
 
-    /// Applies the mutation operator to the given source code.
+    /// Applies the mutation operator to the given source code, by calling the mutation operator's apply method.
+    /// Returns differently mutated source code listings in a vector.
     pub fn apply(&self, source: &str) -> Vec<String> {
         self.operator.apply(source)
     }

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,0 +1,22 @@
+use crate::operator::MutationOperator;
+use std::fmt;
+
+/// A mutant is a piece of code that has been mutated by the mutation operator.
+/// This represents mutant as a mutation operator.
+#[derive(Debug, Clone)]
+pub struct Mutant {
+    operator: MutationOperator,
+}
+
+impl Mutant {
+    /// Creates a new mutant.
+    pub fn new(operator: MutationOperator) -> Self {
+        Self { operator }
+    }
+}
+
+impl fmt::Display for Mutant {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Mutant: {}", self.operator)
+    }
+}

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -1,0 +1,87 @@
+use move_compiler::parser;
+use move_compiler::parser::ast::{FunctionBody_, SequenceItem_};
+
+use crate::mutant::Mutant;
+use crate::operator::MutationOperator;
+use move_compiler::parser::ast::{Definition::Module, ModuleMember};
+
+/// Traverses the AST, identifies places where mutation operators can be applied
+/// and returns a list of mutants.
+pub fn mutate(ast: parser::ast::Program) -> anyhow::Result<Vec<Mutant>> {
+    let mutants = ast
+        .source_definitions
+        .into_iter()
+        .filter_map(|package| match package.def {
+            Module(module) => Some(traverse_module(module)),
+            _ => None,
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .concat();
+
+    Ok(mutants)
+}
+
+fn traverse_module(module: parser::ast::ModuleDefinition) -> anyhow::Result<Vec<Mutant>> {
+    let mutants = module
+        .members
+        .into_iter()
+        .filter_map(|member| match member {
+            ModuleMember::Function(func) => Some(traverse_function(func)),
+            _ => None,
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .concat();
+
+    Ok(mutants)
+}
+
+fn traverse_function(function: parser::ast::Function) -> anyhow::Result<Vec<Mutant>> {
+    match function.body.value {
+        FunctionBody_::Defined(elem) => {
+            let (_, seq, _, exp) = elem;
+            let mut mutants = seq
+                .into_iter()
+                .map(traverse_sequence_item)
+                .collect::<Result<Vec<_>, _>>()?
+                .concat();
+
+            // exp represents the return expression so we need to remember to parse it
+            mutants.extend(parse_expression(exp.unwrap())?);
+            Ok(mutants)
+        },
+        _ => Ok(vec![]),
+    }
+}
+
+fn traverse_sequence_item(seq_item: parser::ast::SequenceItem) -> anyhow::Result<Vec<Mutant>> {
+    match seq_item.value {
+        SequenceItem_::Bind(_, _, exp) | SequenceItem_::Seq(exp) => parse_expression(*exp),
+        SequenceItem_::Declare(_bl, _type) => Ok(vec![]),
+    }
+}
+
+fn parse_expression(exp: parser::ast::Exp) -> anyhow::Result<Vec<Mutant>> {
+    match exp.value {
+        parser::ast::Exp_::BinopExp(left, binop, right) => {
+            // Parse left and right side of the operator as they are expressions and may contain
+            // another things to mutate
+            let mut mutants = parse_expression(*left)?;
+            mutants.extend(parse_expression(*right)?);
+
+            // Add the mutation operator to the list of mutants
+            mutants.push(Mutant::new(MutationOperator::BinaryOperator(binop)));
+
+            Ok(mutants)
+        },
+        parser::ast::Exp_::UnaryExp(unop, exp) => {
+            // Parse the expression as it may contain another things to mutate
+            let mut mutants = parse_expression(*exp)?;
+
+            // Add the mutation operator to the list of mutants
+            mutants.push(Mutant::new(MutationOperator::UnaryOperator(unop)));
+
+            Ok(mutants)
+        },
+        _ => Ok(vec![]),
+    }
+}

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -1,9 +1,12 @@
 use move_compiler::parser;
-use move_compiler::parser::ast::{FunctionBody_, SequenceItem_};
+use move_compiler::parser::ast::{Exp, FunctionBody_, SequenceItem_};
 
 use crate::mutant::Mutant;
 use crate::operator::MutationOperator;
-use move_compiler::parser::ast::{Definition::Module, ModuleMember};
+use move_compiler::parser::ast::{
+    Definition::{Address, Module, Script},
+    ModuleMember,
+};
 
 /// Traverses the AST, identifies places where mutation operators can be applied
 /// and returns a list of mutants.
@@ -11,9 +14,14 @@ pub fn mutate(ast: parser::ast::Program) -> anyhow::Result<Vec<Mutant>> {
     let mutants = ast
         .source_definitions
         .into_iter()
-        .filter_map(|package| match package.def {
-            Module(module) => Some(traverse_module(module)),
-            _ => None,
+        .flat_map(|package| match package.def {
+            Address(addr) => addr
+                .modules
+                .into_iter()
+                .map(traverse_module)
+                .collect::<Vec<Result<Vec<_>, _>>>(),
+            Module(module) => vec![traverse_module(module)],
+            Script(script) => vec![traverse_function(script.function)],
         })
         .collect::<Result<Vec<_>, _>>()?
         .concat();
@@ -27,6 +35,7 @@ fn traverse_module(module: parser::ast::ModuleDefinition) -> anyhow::Result<Vec<
         .into_iter()
         .filter_map(|member| match member {
             ModuleMember::Function(func) => Some(traverse_function(func)),
+            ModuleMember::Constant(constant) => Some(parse_expression(constant.value)),
             _ => None,
         })
         .collect::<Result<Vec<_>, _>>()?
@@ -37,20 +46,25 @@ fn traverse_module(module: parser::ast::ModuleDefinition) -> anyhow::Result<Vec<
 
 fn traverse_function(function: parser::ast::Function) -> anyhow::Result<Vec<Mutant>> {
     match function.body.value {
-        FunctionBody_::Defined(elem) => {
-            let (_, seq, _, exp) = elem;
-            let mut mutants = seq
-                .into_iter()
-                .map(traverse_sequence_item)
-                .collect::<Result<Vec<_>, _>>()?
-                .concat();
-
-            // exp represents the return expression so we need to remember to parse it
-            mutants.extend(parse_expression(exp.unwrap())?);
-            Ok(mutants)
-        },
+        FunctionBody_::Defined(elem) => traverse_sequence(elem),
         _ => Ok(vec![]),
     }
+}
+
+fn traverse_sequence(elem: parser::ast::Sequence) -> anyhow::Result<Vec<Mutant>> {
+    let (_, seq, _, exp) = elem;
+    let mut mutants = seq
+        .into_iter()
+        .map(traverse_sequence_item)
+        .collect::<Result<Vec<_>, _>>()?
+        .concat();
+
+    // exp represents the return expression so we need to remember to parse it
+    if let Some(exp) = *exp {
+        mutants.extend(parse_expression(exp)?);
+    }
+
+    Ok(mutants)
 }
 
 fn traverse_sequence_item(seq_item: parser::ast::SequenceItem) -> anyhow::Result<Vec<Mutant>> {
@@ -58,6 +72,14 @@ fn traverse_sequence_item(seq_item: parser::ast::SequenceItem) -> anyhow::Result
         SequenceItem_::Bind(_, _, exp) | SequenceItem_::Seq(exp) => parse_expression(*exp),
         SequenceItem_::Declare(_bl, _type) => Ok(vec![]),
     }
+}
+
+fn parse_expressions(exp: Vec<parser::ast::Exp>) -> anyhow::Result<Vec<Mutant>> {
+    Ok(exp
+        .into_iter()
+        .map(parse_expression)
+        .collect::<Result<Vec<_>, _>>()?
+        .concat())
 }
 
 fn parse_expression(exp: parser::ast::Exp) -> anyhow::Result<Vec<Mutant>> {
@@ -82,6 +104,47 @@ fn parse_expression(exp: parser::ast::Exp) -> anyhow::Result<Vec<Mutant>> {
 
             Ok(mutants)
         },
+        parser::ast::Exp_::Assign(exp1, exp2) | parser::ast::Exp_::While(exp1, exp2) => {
+            let mut mutants = parse_expression(*exp1)?;
+            mutants.extend(parse_expression(*exp2)?);
+            Ok(mutants)
+        },
+        parser::ast::Exp_::Block(seq) => traverse_sequence(seq),
+        parser::ast::Exp_::Pack(_, _, exps) => {
+            let exps = exps.into_iter().map(|(_, exp)| exp).collect::<Vec<Exp>>();
+            parse_expressions(exps)
+        },
+        parser::ast::Exp_::Call(_, _, _, exps) | parser::ast::Exp_::Vector(_, _, exps) => parse_expressions(exps.value),
+        parser::ast::Exp_::ExpList(exps) => parse_expressions(exps),
+        parser::ast::Exp_::IfElse(exp1, exp2, exp3) => {
+            let mut mutants = parse_expression(*exp1)?;
+            mutants.extend(parse_expression(*exp2)?);
+            if let Some(exp3) = exp3 {
+                mutants.extend(parse_expression(*exp3)?);
+            }
+            Ok(mutants)
+        },
+        parser::ast::Exp_::Quant(_, _, vexp, lexp, exp) => {
+            let mut mutants = vec![];
+            for exp in vexp {
+                let muts = parse_expressions(exp)?;
+                mutants.extend(muts);
+            }
+            if let Some(lexp) = lexp {
+                mutants.extend(parse_expression(*lexp)?);
+            }
+            mutants.extend(parse_expression(*exp)?);
+            Ok(mutants)
+        },
+        parser::ast::Exp_::Return(Some(exp)) => parse_expression(*exp),
+        parser::ast::Exp_::Abort(exp)
+        | parser::ast::Exp_::Annotate(exp, _)
+        | parser::ast::Exp_::Borrow(_, exp)
+        | parser::ast::Exp_::Cast(exp, _)
+        | parser::ast::Exp_::Dereference(exp)
+        | parser::ast::Exp_::Dot(exp, _)
+        | parser::ast::Exp_::Loop(exp)
+        | parser::ast::Exp_::Lambda(_, exp) => parse_expression(*exp),
         _ => Ok(vec![]),
     }
 }

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,4 +1,5 @@
-use move_compiler::parser::ast::{BinOp, UnaryOp};
+use move_command_line_common::files::FileHash;
+use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp};
 use std::fmt;
 
 /// The mutation operator to apply.
@@ -6,6 +7,64 @@ use std::fmt;
 pub enum MutationOperator {
     BinaryOperator(BinOp),
     UnaryOperator(UnaryOp),
+}
+
+impl MutationOperator {
+    /// Applies the mutation operator to the given source code.
+    /// Returns a vector of mutated source code.
+    pub fn apply(&self, source: &str) -> Vec<String> {
+        match self {
+            MutationOperator::BinaryOperator(bin_op) => {
+                let start = bin_op.loc.start() as usize;
+                let end = bin_op.loc.end() as usize;
+                let op = &source[start..end];
+
+                let ops: Vec<&str> = match bin_op.value {
+                    BinOp_::Add | BinOp_::Sub | BinOp_::Mul | BinOp_::Div | BinOp_::Mod => {
+                        vec!["+", "-", "*", "/", "%"]
+                    },
+                    BinOp_::BitOr | BinOp_::BitAnd | BinOp_::Xor => {
+                        vec!["|", "&", "^"]
+                    },
+                    BinOp_::Shl | BinOp_::Shr => {
+                        vec!["<<", ">>"]
+                    },
+                    _ => vec![],
+                };
+
+                ops.into_iter()
+                    .filter(|v| op != *v)
+                    .map(|op| {
+                        let mut mutated_source = source.to_string();
+                        mutated_source.replace_range(start..end, op);
+                        mutated_source
+                    })
+                    .collect()
+            },
+            MutationOperator::UnaryOperator(unary_op) => {
+                let start = unary_op.loc.start() as usize;
+                let end = unary_op.loc.end() as usize;
+
+                // For unary operator mutations, we only need to replace the operator with a space (to ensure the same file length)
+                vec![" "]
+                    .into_iter()
+                    .map(|op| {
+                        let mut mutated_source = source.to_string();
+                        mutated_source.replace_range(start..end, op);
+                        mutated_source
+                    })
+                    .collect()
+            },
+        }
+    }
+
+    /// Returns the file hash of the file that this mutation operator is in.
+    pub fn get_file_hash(&self) -> FileHash {
+        match self {
+            MutationOperator::BinaryOperator(bin_op) => bin_op.loc.file_hash(),
+            MutationOperator::UnaryOperator(unary_op) => unary_op.loc.file_hash(),
+        }
+    }
 }
 
 impl fmt::Display for MutationOperator {
@@ -28,5 +87,50 @@ impl fmt::Display for MutationOperator {
                 unary_op.loc.end()
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_command_line_common::files::FileHash;
+    use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp, UnaryOp_};
+    use move_ir_types::location::Loc;
+
+    #[test]
+    fn test_apply_binary_operator() {
+        let loc = Loc::new(FileHash::new(""), 0, 1);
+        let bin_op = BinOp {
+            value: BinOp_::Mul,
+            loc,
+        };
+        let operator = MutationOperator::BinaryOperator(bin_op);
+        let source = "*";
+        let expected = vec!["+", "-", "/", "%"];
+        assert_eq!(operator.apply(source), expected);
+    }
+
+    #[test]
+    fn test_apply_unary_operator() {
+        let loc = Loc::new(FileHash::new(""), 0, 1);
+        let unary_op = UnaryOp {
+            value: UnaryOp_::Not,
+            loc,
+        };
+        let operator = MutationOperator::UnaryOperator(unary_op);
+        let source = "!";
+        let expected = vec![" "];
+        assert_eq!(operator.apply(source), expected);
+    }
+
+    #[test]
+    fn test_get_file_hash() {
+        let loc = Loc::new(FileHash::new(""), 0, 0);
+        let bin_op = BinOp {
+            value: BinOp_::Add,
+            loc,
+        };
+        let operator = MutationOperator::BinaryOperator(bin_op);
+        assert_eq!(operator.get_file_hash(), FileHash::new(""));
     }
 }

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,0 +1,32 @@
+use move_compiler::parser::ast::{BinOp, UnaryOp};
+use std::fmt;
+
+/// The mutation operator to apply.
+#[derive(Debug, Copy, Clone)]
+pub enum MutationOperator {
+    BinaryOperator(BinOp),
+    UnaryOperator(UnaryOp),
+}
+
+impl fmt::Display for MutationOperator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MutationOperator::BinaryOperator(bin_op) => write!(
+                f,
+                "BinaryOperator({}, location: file hash: {}, index start: {}, index stop: {})",
+                bin_op.value,
+                bin_op.loc.file_hash(),
+                bin_op.loc.start(),
+                bin_op.loc.end()
+            ),
+            MutationOperator::UnaryOperator(unary_op) => write!(
+                f,
+                "UnaryOperator({}, location: file hash: {}, index start: {}, index stop: {})",
+                unary_op.value,
+                unary_op.loc.file_hash(),
+                unary_op.loc.start(),
+                unary_op.loc.end()
+            ),
+        }
+    }
+}

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -11,7 +11,7 @@ pub enum MutationOperator {
 
 impl MutationOperator {
     /// Applies the mutation operator to the given source code.
-    /// Returns a vector of mutated source code.
+    /// Returns differently mutated source code listings in a vector.
     pub fn apply(&self, source: &str) -> Vec<String> {
         match self {
             MutationOperator::BinaryOperator(bin_op) => {
@@ -19,6 +19,8 @@ impl MutationOperator {
                 let end = bin_op.loc.end() as usize;
                 let op = &source[start..end];
 
+                // Group of exchangeable binary operators - we only want to replace the operator with a different one
+                // within the same group.
                 let ops: Vec<&str> = match bin_op.value {
                     BinOp_::Add | BinOp_::Sub | BinOp_::Mul | BinOp_::Div | BinOp_::Mod => {
                         vec!["+", "-", "*", "/", "%"]

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "simple"
+version = "0.0.0"
+
+[addresses]
+TestAccount = "0xCAFE"

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Negation.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Negation.move
@@ -1,0 +1,9 @@
+module TestAccount::Negation {
+    fun neg_log(x: bool): bool {
+        !x
+    }
+
+    spec neg_log {
+        ensures result == !x;
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
@@ -1,0 +1,85 @@
+module TestAccount::Operators {
+    fun sum(x: u64, y: u64): u64 {
+        x + y
+    }
+
+    fun sub(x: u64, y: u64): u64 {
+        x - y
+    }
+
+    fun mul(x: u64, y: u64): u64 {
+        x * y
+    }
+
+    fun mod(x: u64, y: u64): u64 {
+        x % y
+    }
+
+    fun div(x: u64, y: u64): u64 {
+        x / y
+    }
+
+    fun and(x: u64, y: u64): u64 {
+        x & y
+    }
+
+    fun or(x: u64, y: u64): u64 {
+        x | y
+    }
+
+    fun xor(x: u64, y: u64): u64 {
+        x ^ y
+    }
+
+    fun lsh(x: u64, y: u8): u64 {
+        x << y
+    }
+
+    fun rsh(x: u64, y: u8): u64 {
+        x >> y
+    }
+
+    spec sum {
+        ensures result == x+y;
+    }
+
+    spec sub {
+        ensures result == x-y;
+    }
+
+    spec mul {
+        ensures result == x*y;
+    }
+
+    spec mod {
+        aborts_if y == 0;
+        ensures result == x%y;
+    }
+
+    spec div {
+        aborts_if y == 0;
+        ensures result == x/y;
+    }
+
+    spec and {
+        ensures result == int2bv(x) & int2bv(y);
+    }
+
+    spec or {
+        ensures result == int2bv(x) | int2bv(y);
+    }
+
+    spec xor {
+        ensures result == int2bv(x) ^ int2bv(y);
+    }
+
+    spec lsh {
+        aborts_if y >= 64;
+        ensures result == x<<y;
+    }
+
+    spec rsh {
+        aborts_if y >= 64;
+        ensures result == x>>y;
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/StillSimple.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/StillSimple.move
@@ -1,0 +1,49 @@
+module TestAccount::StillSimple {
+    fun sample1(x: u128, y: u128) {
+        let _sum_r = x + y;
+
+	    if ((x + y) < 0) abort 1;
+    }
+
+    inline fun apply(v: u64, predicate: |u64| bool): bool {
+        predicate(v)
+    }
+
+    fun sample2(a1: u64, a2: u64) {
+        let _lamb = apply(0, |v| v != a1 + a2);
+    }
+
+    public fun sample3(n: u64, e: u64): u64 {
+        if (e == 0) {
+            1
+        } else {
+            n * sample3(n, e - 1)
+        }
+    }
+
+    spec sample3 {
+        pragma opaque;
+    }
+
+    fun sample4(x: u128, y: u128) {
+        loop {
+            if (x > y) {
+                y = y + 1;
+                continue
+            };
+            if (y > x) {
+                x = x + 1;
+                continue
+            };
+            break
+        };
+    }
+
+    fun sample5(x: u128, y: u128): u128 {
+        (x - 1 as u128) + (y - 1 as u128)
+    }
+
+    fun sample6(x: u128, y: u128): u128 {
+        return (x + y - x*(y + 2)*x/y)
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
@@ -1,0 +1,10 @@
+module TestAccount::Sum {
+    fun sum(x: u128, y: u128): u128 {
+        let sum_r = x + y;
+        spec {
+                assert sum_r == x+y;
+        };
+
+        sum_r
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the The Move mutator proof-of-concept. The Move mutator is a tool that mutates Move source code. It is used to help test the robustness of Move analyzers and verifiers by generating different code versions (mutants). It's part of the more significant project to create a Move Specification Verification toolset.

This PR implements the main mutator logic. Functions have been added for traversing the Abstract Syntax Tree (AST) of the Move source code and searching for places where potential mutation operators can be applied. It has been AST from the `parser` Move compiler module used. 

The idea behind the above search is as follows: a `mutate` function is the entry point. It takes the AST of a Move program as input and returns a list of mutations (not yet generated). It does this by iterating over the source definitions in the AST and calling the appropriate function to traverse each definition based on its type (Address, Module, or Script). There are several functions to go through different types of AST nodes. 

The main parsing function is the `parse_expression`. It checks the type of the expression and marks that place as the appropriate for the mutation operator to be applied (e.g., binary or unary expressions). Sub-expressions are parsed recursively.

When a new place for mutation is found, the mutation operator is passed as an argument containing the appropriate AST node. As each node has its own location (`Spanned` structure with `Loc`) it's possible to pass the node without any additional overhead. This process continues recursively until all nodes in the AST have been visited and all possible mutations have been generated. The `mutate` function then returns the list of mutations.

Those mutations are applied during output generation. Each mutation is run through the `apply` function, which applies the mutation operator to sources. That produces an output file (mutant) which can be saved.

Currently supported operators:
- binary operator replacement
- unary operator replacement

The Move mutator tool is integrated with the `move-cli` and `aptos` command line interfaces. There is introduced a new command: `mutate`, which allows to pass the mutator arguments and it generates the output. Mutants are currently stored in the `mutants_output` directory, and there is no way to change it. Mutants are just saved in a flat structure (no subdirectories). Each mutant filename consists of the original source filename with the next index appended.

The report is generated on screen and lists all generated mutants (which mutation operator was used, location in the original source file, and mutant output). It's not possible to create the report in a file.

## Test plan

Unit tests can be run by calling:
```bash
cargo test -p move-mutator
```

Sample Move files from `third_party/move/tools/move-mutator/tests/move-assets/simple/` may be used to check mutant generation.

There are also good tests in the Move Prover repository that can be used to test the tool. They are:
```
third_party/move/move-prover/tests/sources/functional/arithm.move
third_party/move/move-prover/tests/sources/functional/bitwise_operators.move
third_party/move/move-prover/tests/sources/functional/nonlinear_arithm.move
third_party/move/move-prover/tests/sources/functional/shift.move
```

Check [README.md](https://github.com/eigerco/aptos-core/blob/401de038408bd9ad12dbcf864701b85716ecad12/third_party/move/tools/move-mutator/README.md) for more information how to run the tests and what results should be expected.