### PR TITLE
[move-mutator] Report generation

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -14,8 +14,10 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = "1.0"
+diffy = "0.3"
 clap = { version = "4.3", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 toml = "0.5"
 
 move-command-line-common = { path = "../../move-command-line-common" }

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -56,21 +56,50 @@ JSON report format sample:
 
 ```json
 {
-    "mutants": [
-        {
-            "id": 1,
-            "operator": "binary_operator_replacement",
-            "category": "arithmetic",
-            "location": {
-                "file": "path/to/file",
-                "start_index": 1,
-                "stop_index": 1
+    "mutations": [
+      {
+        "file": "mutants_output/shift_0.move",
+        "original_file": "third_party/move/move-prover/tests/sources/functional/shift.move",
+        "modifications": [
+          {
+            "changed_place": {
+              "start": 243,
+              "end": 245
             },
-            "original": "original expression",
-            "mutant": "mutated expression"
-        }
+            "operator_name": "BinaryOperator",
+            "old_value": "<<",
+            "new_value": ">>"
+          }
+        ],
+        "diff": "--- original\n+++ modified\n@@ -5,7 +5,7 @@\n module 0x42::TestShift {\n\n     fun shiftl_1_correct(x: u64): u64 {\n-        x << 1\n+        x >> 1\n     }\n\n     spec shiftl_1_correct {\n"
+      }
     ]
 }
+```
+
+Text format sample:
+```
+File: mutants_output/shift_0.move
+Original file: third_party/move/move-prover/tests/sources/functional/shift.move
+Modifications:
+  Operator: binary_operator_replacement
+  Old value: <<
+  New value: >>
+  Changed place: 243-245
+Diff:
+--- original
++++ modified
+@@ -5,7 +5,7 @@
+ module 0x42::TestShift {
+
+     fun shiftl_1_correct(x: u64): u64 {
+-        x << 1
++        x >> 1
+     }
+
+     spec shiftl_1_correct {
+
+----------------------------------------
 ```
 
 ### Service layer

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -56,11 +56,11 @@ JSON report format sample:
 
 ```json
 {
-    "mutations": [
+    "mutants": [
       {
         "file": "mutants_output/shift_0.move",
         "original_file": "third_party/move/move-prover/tests/sources/functional/shift.move",
-        "modifications": [
+        "mutations": [
           {
             "changed_place": {
               "start": 243,
@@ -81,7 +81,7 @@ Text format sample:
 ```
 File: mutants_output/shift_0.move
 Original file: third_party/move/move-prover/tests/sources/functional/shift.move
-Modifications:
+Mutations:
   Operator: binary_operator_replacement
   Old value: <<
   New value: >>

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -58,7 +58,7 @@ JSON report format sample:
 {
     "mutants": [
       {
-        "file": "mutants_output/shift_0.move",
+        "mutant_path": "mutants_output/shift_0.move",
         "original_file": "third_party/move/move-prover/tests/sources/functional/shift.move",
         "mutations": [
           {
@@ -79,7 +79,7 @@ JSON report format sample:
 
 Text format sample:
 ```
-File: mutants_output/shift_0.move
+Mutant path: mutants_output/shift_0.move
 Original file: third_party/move/move-prover/tests/sources/functional/shift.move
 Mutations:
   Operator: binary_operator_replacement

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -45,10 +45,14 @@ pub fn run_move_mutator(
         for mutant in mutants.iter().filter(|m| m.get_file_hash() == hash) {
             let mutated_sources = mutant.apply(&source);
             for mutated in mutated_sources {
-                let mut_path = format!("mutants_output/{}_{}.move", file_name, i);
-                println!("{} written to {}", mutant, &mut_path);
-                std::fs::write(mut_path.clone(), &mutated.mutated_source)?;
-                let mut entry = report::MutationReport::new(mut_path, filename.to_string());
+                let mutant_path = PathBuf::from(format!("mutants_output/{}_{}.move", file_name, i));
+                println!(
+                    "{} written to {}",
+                    mutant,
+                    mutant_path.to_str().unwrap_or("")
+                );
+                std::fs::write(&mutant_path, &mutated.mutated_source)?;
+                let mut entry = report::MutationReport::new(mutant_path.as_path(), path);
                 entry.add_modification(mutated.mutation);
                 entry.generate_diff(&source, &mutated.mutated_source);
                 report.add_entry(entry);
@@ -57,8 +61,8 @@ pub fn run_move_mutator(
         }
     }
 
-    report.save_to_json_file("mutants_output/report.json")?;
-    report.save_to_text_file("mutants_output/report.txt")?;
+    report.save_to_json_file(Path::new("mutants_output/report.json"))?;
+    report.save_to_text_file(Path::new("mutants_output/report.txt"))?;
 
     Ok(())
 }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -3,13 +3,14 @@ mod compiler;
 
 mod mutate;
 
-mod operator;
-
 mod mutant;
+mod operator;
+mod report;
 
 use crate::compiler::generate_ast;
 use std::path::Path;
 
+use crate::report::Report;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
@@ -34,6 +35,8 @@ pub fn run_move_mutator(
     let _ = std::fs::remove_dir_all(OUTPUT_DIR);
     std::fs::create_dir(OUTPUT_DIR)?;
 
+    let mut report: Report = Report::new();
+
     for (hash, (filename, source)) in files {
         let path = Path::new(filename.as_str());
         let file_name = path.file_stem().unwrap().to_str().unwrap();
@@ -41,14 +44,21 @@ pub fn run_move_mutator(
         let mut i = 0;
         for mutant in mutants.iter().filter(|m| m.get_file_hash() == hash) {
             let mutated_sources = mutant.apply(&source);
-            for source in mutated_sources {
+            for mutated in mutated_sources {
                 let mut_path = format!("mutants_output/{}_{}.move", file_name, i);
                 println!("{} written to {}", mutant, &mut_path);
-                std::fs::write(mut_path, source)?;
+                std::fs::write(mut_path.clone(), &mutated.mutated_source)?;
+                let mut entry = report::ReportEntry::new(mut_path, filename.to_string());
+                entry.add_modification(mutated.modification);
+                entry.generate_diff(&source, &mutated.mutated_source);
+                report.add_entry(entry);
                 i += 1;
             }
         }
     }
+
+    report.save_to_json_file("mutants_output/report.json")?;
+    report.save_to_text_file("mutants_output/report.txt")?;
 
     Ok(())
 }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -48,8 +48,8 @@ pub fn run_move_mutator(
                 let mut_path = format!("mutants_output/{}_{}.move", file_name, i);
                 println!("{} written to {}", mutant, &mut_path);
                 std::fs::write(mut_path.clone(), &mutated.mutated_source)?;
-                let mut entry = report::ReportEntry::new(mut_path, filename.to_string());
-                entry.add_modification(mutated.modification);
+                let mut entry = report::MutationReport::new(mut_path, filename.to_string());
+                entry.add_modification(mutated.mutation);
                 entry.generate_diff(&source, &mutated.mutated_source);
                 report.add_entry(entry);
                 i += 1;

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -52,9 +52,8 @@ pub fn run_move_mutator(
                     mutant_path.to_str().unwrap_or("")
                 );
                 std::fs::write(&mutant_path, &mutated.mutated_source)?;
-                let mut entry = report::MutationReport::new(mutant_path.as_path(), path);
+                let mut entry = report::MutationReport::new(mutant_path.as_path(), path, &mutated.mutated_source, &source);
                 entry.add_modification(mutated.mutation);
-                entry.generate_diff(&source, &mutated.mutated_source);
                 report.add_entry(entry);
                 i += 1;
             }

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,4 +1,4 @@
-use crate::operator::{MutationOperator, MutantInfo};
+use crate::operator::{MutantInfo, MutationOperator};
 use move_command_line_common::files::FileHash;
 use std::fmt;
 

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,4 +1,4 @@
-use crate::operator::{MutationOperator, MutationResult};
+use crate::operator::{MutationOperator, MutantInfo};
 use move_command_line_common::files::FileHash;
 use std::fmt;
 
@@ -22,7 +22,7 @@ impl Mutant {
 
     /// Applies the mutation operator to the given source code, by calling the mutation operator's apply method.
     /// Returns differently mutated source code listings in a vector.
-    pub fn apply(&self, source: &str) -> Vec<MutationResult> {
+    pub fn apply(&self, source: &str) -> Vec<MutantInfo> {
         self.operator.apply(source)
     }
 }

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,4 +1,4 @@
-use crate::operator::MutationOperator;
+use crate::operator::{MutationOperator, MutationResult};
 use move_command_line_common::files::FileHash;
 use std::fmt;
 
@@ -22,7 +22,7 @@ impl Mutant {
 
     /// Applies the mutation operator to the given source code, by calling the mutation operator's apply method.
     /// Returns differently mutated source code listings in a vector.
-    pub fn apply(&self, source: &str) -> Vec<String> {
+    pub fn apply(&self, source: &str) -> Vec<MutationResult> {
         self.operator.apply(source)
     }
 }
@@ -72,6 +72,10 @@ mod tests {
         let mutant = Mutant::new(operator);
         let source = "+";
         let expected = vec!["-", "*", "/", "%"];
-        assert_eq!(mutant.apply(source), expected);
+        let result = mutant.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
     }
 }

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,22 +1,22 @@
-use crate::report::{Modification, Range};
+use crate::report::{Mutation, Range};
 use move_command_line_common::files::FileHash;
 use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp};
 use std::fmt;
 
 /// Mutation result that contains the mutated source code and the modification that was applied.
-pub struct MutationResult {
+pub struct MutantInfo {
     /// The mutated source code.
     pub mutated_source: String,
     /// The modification that was applied.
-    pub modification: Modification,
+    pub mutation: Mutation,
 }
 
-impl MutationResult {
+impl MutantInfo {
     /// Creates a new mutation result.
-    pub fn new(mutated_source: String, modification: Modification) -> Self {
+    pub fn new(mutated_source: String, mutation: Mutation) -> Self {
         Self {
             mutated_source,
-            modification,
+            mutation,
         }
     }
 }
@@ -31,7 +31,7 @@ pub enum MutationOperator {
 impl MutationOperator {
     /// Applies the mutation operator to the given source code.
     /// Returns differently mutated source code listings in a vector.
-    pub fn apply(&self, source: &str) -> Vec<MutationResult> {
+    pub fn apply(&self, source: &str) -> Vec<MutantInfo> {
         match self {
             MutationOperator::BinaryOperator(bin_op) => {
                 let start = bin_op.loc.start() as usize;
@@ -58,9 +58,9 @@ impl MutationOperator {
                     .map(|op| {
                         let mut mutated_source = source.to_string();
                         mutated_source.replace_range(start..end, op);
-                        MutationResult::new(
+                        MutantInfo::new(
                             mutated_source,
-                            Modification::new(
+                            Mutation::new(
                                 Range::new(start, end),
                                 "binary_operator_replacement".to_string(),
                                 cur_op.to_string(),
@@ -81,9 +81,9 @@ impl MutationOperator {
                     .map(|op| {
                         let mut mutated_source = source.to_string();
                         mutated_source.replace_range(start..end, op);
-                        MutationResult::new(
+                        MutantInfo::new(
                             mutated_source,
-                            Modification::new(
+                            Mutation::new(
                                 Range::new(start, end),
                                 "unary_operator_replacement".to_string(),
                                 cur_op.to_string(),

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,6 +1,25 @@
+use crate::report::{Modification, Range};
 use move_command_line_common::files::FileHash;
 use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp};
 use std::fmt;
+
+/// Mutation result that contains the mutated source code and the modification that was applied.
+pub struct MutationResult {
+    /// The mutated source code.
+    pub mutated_source: String,
+    /// The modification that was applied.
+    pub modification: Modification,
+}
+
+impl MutationResult {
+    /// Creates a new mutation result.
+    pub fn new(mutated_source: String, modification: Modification) -> Self {
+        Self {
+            mutated_source,
+            modification,
+        }
+    }
+}
 
 /// The mutation operator to apply.
 #[derive(Debug, Copy, Clone)]
@@ -12,12 +31,12 @@ pub enum MutationOperator {
 impl MutationOperator {
     /// Applies the mutation operator to the given source code.
     /// Returns differently mutated source code listings in a vector.
-    pub fn apply(&self, source: &str) -> Vec<String> {
+    pub fn apply(&self, source: &str) -> Vec<MutationResult> {
         match self {
             MutationOperator::BinaryOperator(bin_op) => {
                 let start = bin_op.loc.start() as usize;
                 let end = bin_op.loc.end() as usize;
-                let op = &source[start..end];
+                let cur_op = &source[start..end];
 
                 // Group of exchangeable binary operators - we only want to replace the operator with a different one
                 // within the same group.
@@ -35,17 +54,26 @@ impl MutationOperator {
                 };
 
                 ops.into_iter()
-                    .filter(|v| op != *v)
+                    .filter(|v| cur_op != *v)
                     .map(|op| {
                         let mut mutated_source = source.to_string();
                         mutated_source.replace_range(start..end, op);
-                        mutated_source
+                        MutationResult::new(
+                            mutated_source,
+                            Modification::new(
+                                Range::new(start, end),
+                                "binary_operator_replacement".to_string(),
+                                cur_op.to_string(),
+                                op.to_string(),
+                            ),
+                        )
                     })
                     .collect()
             },
             MutationOperator::UnaryOperator(unary_op) => {
                 let start = unary_op.loc.start() as usize;
                 let end = unary_op.loc.end() as usize;
+                let cur_op = &source[start..end];
 
                 // For unary operator mutations, we only need to replace the operator with a space (to ensure the same file length)
                 vec![" "]
@@ -53,7 +81,15 @@ impl MutationOperator {
                     .map(|op| {
                         let mut mutated_source = source.to_string();
                         mutated_source.replace_range(start..end, op);
-                        mutated_source
+                        MutationResult::new(
+                            mutated_source,
+                            Modification::new(
+                                Range::new(start, end),
+                                "unary_operator_replacement".to_string(),
+                                cur_op.to_string(),
+                                op.to_string(),
+                            ),
+                        )
                     })
                     .collect()
             },
@@ -109,7 +145,11 @@ mod tests {
         let operator = MutationOperator::BinaryOperator(bin_op);
         let source = "*";
         let expected = vec!["+", "-", "/", "%"];
-        assert_eq!(operator.apply(source), expected);
+        let result = operator.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
     }
 
     #[test]
@@ -122,7 +162,11 @@ mod tests {
         let operator = MutationOperator::UnaryOperator(unary_op);
         let source = "!";
         let expected = vec![" "];
-        assert_eq!(operator.apply(source), expected);
+        let result = operator.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
     }
 
     #[test]

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -137,25 +137,20 @@ pub struct MutationReport {
 
 impl MutationReport {
     /// Creates a new `MutationReport` instance.
-    pub fn new(mutant_path: &Path, original_file: &Path) -> Self {
+    /// Generates diff (patch) between the original and mutated source.
+    pub fn new(mutant_path: &Path, original_file: &Path, mutated_source: &str, original_source: &str ) -> Self {
+        let patch = diffy::create_patch(original_source, mutated_source);
         Self {
             mutant_path: mutant_path.to_path_buf(),
             original_file: original_file.to_path_buf(),
             mutations: vec![],
-            diff: String::new(),
+            diff: patch.to_string(),
         }
     }
 
     /// Adds a `Mutation` to the `MutationReport`.
     pub fn add_modification(&mut self, modification: Mutation) {
         self.mutations.push(modification);
-    }
-
-    /// Generate diff (patch) between the original and mutated source.
-    /// The diff is stored in the `MutationReport`.
-    pub fn generate_diff(&mut self, original_source: &str, mutated_source: &str) {
-        let patch = diffy::create_patch(original_source, mutated_source);
-        self.diff = patch.to_string();
     }
 }
 
@@ -177,9 +172,8 @@ mod tests {
             "old".to_string(),
             "new".to_string(),
         );
-        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"));
+        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
         report_entry.add_modification(modification);
-        report_entry.generate_diff("diff\n", "\n");
 
         report.add_entry(report_entry.clone());
         assert_eq!(
@@ -219,7 +213,7 @@ mod tests {
             "old".to_string(),
             "new".to_string(),
         );
-        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"));
+        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
         report_entry.add_modification(modification);
         report.add_entry(report_entry);
 

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -1,0 +1,235 @@
+use serde::Serialize;
+use serde_json;
+use std::io::Write;
+
+/// The `Report` struct represents a report of mutations.
+/// It contains a vector of `ReportEntry` instances.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    /// The vector of `ReportEntry` instances.
+    mutations: Vec<ReportEntry>,
+}
+
+impl Report {
+    /// Creates a new `Report` instance.
+    pub fn new() -> Self {
+        Self {
+            mutations: Vec::new(),
+        }
+    }
+
+    /// Adds a new `ReportEntry` to the report.
+    pub fn add_entry(&mut self, entry: ReportEntry) {
+        self.mutations.push(entry);
+    }
+
+    /// Saves the `Report` as a JSON file.
+    pub fn save_to_json_file(&self, path: &str) -> std::io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        serde_json::to_writer_pretty(file, &self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    }
+
+    /// Saves the `Report` as a text file.
+    pub fn save_to_text_file(&self, path: &str) -> std::io::Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        for entry in &self.mutations {
+            writeln!(file, "File: {}", entry.file)?;
+            writeln!(file, "Original file: {}", entry.original_file)?;
+            writeln!(file, "Modifications:")?;
+            for modification in &entry.modifications {
+                writeln!(file, "  Operator: {}", modification.operator_name)?;
+                writeln!(file, "  Old value: {}", modification.old_value)?;
+                writeln!(file, "  New value: {}", modification.new_value)?;
+                writeln!(file, "  Changed place: {}-{}", modification.changed_place.start, modification.changed_place.end)?;
+            }
+            writeln!(file, "Diff:")?;
+            writeln!(file, "{}", entry.diff)?;
+            writeln!(file, "----------------------------------------")?;
+        }
+        Ok(())
+    }
+
+    /// Converts the `Report` to a JSON string.
+    #[cfg(test)]
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+/// The `Range` struct represents a range with a start and end.
+/// It is used to represent the location of a mutation inside the source file.
+#[derive(Debug, Clone, Serialize)]
+pub struct Range {
+    /// The start of the range.
+    start: usize,
+    /// The end of the range.
+    end: usize,
+}
+
+impl Range {
+    /// Creates a new `Range` instance.
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}
+
+/// The `Modification` struct represents a modification that was applied to a file.
+/// It contains the location of the modification, the name of the mutation operator, the old value and the new value.
+/// It is used to represent a single modification inside a `ReportEntry`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Modification {
+    /// The location of the modification.
+    changed_place: Range,
+    /// The name of the mutation operator.
+    operator_name: String,
+    /// The old operator value.
+    old_value: String,
+    /// The new operator value.
+    new_value: String,
+}
+
+impl Modification {
+    /// Creates a new `Modification` instance.
+    pub fn new(
+        changed_place: Range,
+        operator_name: String,
+        old_value: String,
+        new_value: String,
+    ) -> Self {
+        Self {
+            changed_place,
+            operator_name,
+            old_value,
+            new_value,
+        }
+    }
+}
+
+/// The `ReportEntry` struct represents an entry in a report.
+/// It contains information about a mutation that was applied to a file.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReportEntry {
+    /// The path to the mutated file.
+    file: String,
+    /// The path to the original file.
+    original_file: String,
+    /// The modifications that were applied to the file.
+    modifications: Vec<Modification>,
+    /// The diff between the original and mutated file.
+    diff: String,
+}
+
+impl ReportEntry {
+    /// Creates a new `ReportEntry` instance.
+    pub fn new(file: String, original_file: String) -> Self {
+        Self {
+            file,
+            original_file,
+            modifications: vec![],
+            diff: String::new(),
+        }
+    }
+
+    /// Adds a `Modification` to the `ReportEntry`.
+    pub fn add_modification(&mut self, modification: Modification) {
+        self.modifications.push(modification);
+    }
+
+    /// Generate diff (patch) between the original and mutated source.
+    /// The diff is stored in the `ReportEntry`.
+    pub fn generate_diff(&mut self, original_source: &str, mutated_source: &str) {
+        let patch = diffy::create_patch(original_source, mutated_source);
+        self.diff = patch.to_string();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Read;
+
+    #[test]
+    fn test_report() {
+        let mut report = Report::new();
+        assert_eq!(report.to_json().unwrap(), "{\n  \"mutations\": []\n}");
+
+        let range = Range::new(0, 10);
+        let modification = Modification::new(
+            range,
+            "operator".to_string(),
+            "old".to_string(),
+            "new".to_string(),
+        );
+        let mut report_entry = ReportEntry::new("file".to_string(), "original_file".to_string());
+        report_entry.add_modification(modification);
+        report_entry.generate_diff("diff\n", "\n");
+
+        report.add_entry(report_entry.clone());
+        assert_eq!(
+            report.to_json().unwrap(),
+            "{\n  \"mutations\": [\n    {\n      \"file\": \"file\",\n      \"original_file\": \"original_file\",\n      \"modifications\": [\n        {\n          \"changed_place\": {\n            \"start\": 0,\n            \"end\": 10\n          },\n          \"operator_name\": \"operator\",\n          \"old_value\": \"old\",\n          \"new_value\": \"new\"\n        }\n      ],\n      \"diff\": \"--- original\\n+++ modified\\n@@ -1 +1 @@\\n-diff\\n+\\n\"\n    }\n  ]\n}"
+        );
+    }
+
+    #[test]
+    fn test_range() {
+        let range = Range::new(0, 10);
+        assert_eq!(
+            serde_json::to_string(&range).unwrap(),
+            "{\"start\":0,\"end\":10}"
+        );
+    }
+
+    #[test]
+    fn test_modification() {
+        let range = Range::new(0, 10);
+        let modification = Modification::new(
+            range,
+            "operator".to_string(),
+            "old".to_string(),
+            "new".to_string(),
+        );
+        assert_eq!(serde_json::to_string(&modification).unwrap(), "{\"changed_place\":{\"start\":0,\"end\":10},\"operator_name\":\"operator\",\"old_value\":\"old\",\"new_value\":\"new\"}");
+    }
+
+    #[test]
+    fn saves_report_as_text_file_successfully() {
+        let mut report = Report::new();
+        let range = Range::new(0, 10);
+        let modification = Modification::new(
+            range,
+            "operator".to_string(),
+            "old".to_string(),
+            "new".to_string(),
+        );
+        let mut report_entry = ReportEntry::new("file".to_string(), "original_file".to_string());
+        report_entry.add_modification(modification);
+        report.add_entry(report_entry);
+
+        let path = "test_report.txt";
+        report.save_to_text_file(path).unwrap();
+
+        let mut file = fs::File::open(path).unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        assert!(contents.contains("File: file"));
+        assert!(contents.contains("Original file: original_file"));
+        assert!(contents.contains("Modifications:"));
+        assert!(contents.contains("Operator: operator"));
+        assert!(contents.contains("Old value: old"));
+        assert!(contents.contains("New value: new"));
+        assert!(contents.contains("Changed place: 0-10"));
+
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "No such file or directory")]
+    fn fails_to_save_report_to_non_existent_directory() {
+        let report = Report::new();
+        let path = "non_existent_directory/test_report.txt";
+        report.save_to_text_file(path).unwrap();
+    }
+}


### PR DESCRIPTION
This commit adds report generation. Report is stored in the output directory as a separate JSON file named `report.json` and as a plain text file called `report.txt`.

Text file is also stored as it's easier to view diffs in text file than as a string inside JSON field.

Reports contain information about all modifications done in each file. Reports handle single modifications as well as multiple modifications inside one file (which is not yet supported by the `move-mutator`).