### PR TITLE
[move-mutator] Mutation report generation

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -14,8 +14,10 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = "1.0"
+diffy = "0.3"
 clap = { version = "4.3", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 toml = "0.5"
 
 move-command-line-common = { path = "../../move-command-line-common" }

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -57,20 +57,49 @@ JSON report format sample:
 ```json
 {
     "mutants": [
-        {
-            "id": 1,
-            "operator": "binary_operator_replacement",
-            "category": "arithmetic",
-            "location": {
-                "file": "path/to/file",
-                "start_index": 1,
-                "stop_index": 1
+      {
+        "mutant_path": "mutants_output/shift_0.move",
+        "original_file": "third_party/move/move-prover/tests/sources/functional/shift.move",
+        "mutations": [
+          {
+            "changed_place": {
+              "start": 243,
+              "end": 245
             },
-            "original": "original expression",
-            "mutant": "mutated expression"
-        }
+            "operator_name": "BinaryOperator",
+            "old_value": "<<",
+            "new_value": ">>"
+          }
+        ],
+        "diff": "--- original\n+++ modified\n@@ -5,7 +5,7 @@\n module 0x42::TestShift {\n\n     fun shiftl_1_correct(x: u64): u64 {\n-        x << 1\n+        x >> 1\n     }\n\n     spec shiftl_1_correct {\n"
+      }
     ]
 }
+```
+
+Text format sample:
+```
+Mutant path: mutants_output/shift_0.move
+Original file: third_party/move/move-prover/tests/sources/functional/shift.move
+Mutations:
+  Operator: binary_operator_replacement
+  Old value: <<
+  New value: >>
+  Changed place: 243-245
+Diff:
+--- original
++++ modified
+@@ -5,7 +5,7 @@
+ module 0x42::TestShift {
+
+     fun shiftl_1_correct(x: u64): u64 {
+-        x << 1
++        x >> 1
+     }
+
+     spec shiftl_1_correct {
+
+----------------------------------------
 ```
 
 ### Service layer

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,4 +1,4 @@
-use crate::operator::MutationOperator;
+use crate::operator::{MutantInfo, MutationOperator};
 use move_command_line_common::files::FileHash;
 use std::fmt;
 
@@ -22,7 +22,7 @@ impl Mutant {
 
     /// Applies the mutation operator to the given source code, by calling the mutation operator's apply method.
     /// Returns differently mutated source code listings in a vector.
-    pub fn apply(&self, source: &str) -> Vec<String> {
+    pub fn apply(&self, source: &str) -> Vec<MutantInfo> {
         self.operator.apply(source)
     }
 }
@@ -72,6 +72,10 @@ mod tests {
         let mutant = Mutant::new(operator);
         let source = "+";
         let expected = vec!["-", "*", "/", "%"];
-        assert_eq!(mutant.apply(source), expected);
+        let result = mutant.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
     }
 }

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -1,0 +1,244 @@
+use serde::Serialize;
+use serde_json;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// The `Report` struct represents a report of mutations.
+/// It contains a vector of `MutationReport` instances.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    /// The vector of `ReportEntry` instances.
+    mutants: Vec<MutationReport>,
+}
+
+impl Report {
+    /// Creates a new `Report` instance.
+    pub fn new() -> Self {
+        Self {
+            mutants: Vec::new(),
+        }
+    }
+
+    /// Adds a new `MutationReport` to the report.
+    pub fn add_entry(&mut self, entry: MutationReport) {
+        self.mutants.push(entry);
+    }
+
+    /// Saves the `Report` as a JSON file.
+    pub fn save_to_json_file(&self, path: &Path) -> std::io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        serde_json::to_writer_pretty(file, &self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    }
+
+    /// Saves the `Report` as a text file.
+    pub fn save_to_text_file(&self, path: &Path) -> std::io::Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        for entry in &self.mutants {
+            writeln!(
+                file,
+                "Mutant path: {}",
+                entry.mutant_path.to_str().unwrap_or("")
+            )?;
+            writeln!(
+                file,
+                "Original file: {}",
+                entry.original_file.to_str().unwrap_or("")
+            )?;
+            writeln!(file, "Mutations:")?;
+            for modification in &entry.mutations {
+                writeln!(file, "  Operator: {}", modification.operator_name)?;
+                writeln!(file, "  Old value: {}", modification.old_value)?;
+                writeln!(file, "  New value: {}", modification.new_value)?;
+                writeln!(
+                    file,
+                    "  Changed place: {}-{}",
+                    modification.changed_place.start, modification.changed_place.end
+                )?;
+            }
+            writeln!(file, "Diff:")?;
+            writeln!(file, "{}", entry.diff)?;
+            writeln!(file, "----------------------------------------")?;
+        }
+        Ok(())
+    }
+
+    /// Converts the `Report` to a JSON string.
+    #[cfg(test)]
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(&self)
+    }
+}
+
+/// The `Range` struct represents a range with a start and end.
+/// It is used to represent the location of a mutation inside the source file.
+#[derive(Debug, Clone, Serialize)]
+pub struct Range {
+    /// The start of the range.
+    start: usize,
+    /// The end of the range.
+    end: usize,
+}
+
+impl Range {
+    /// Creates a new `Range` instance.
+    /// The start must be smaller or equal to the end.
+    pub fn new(start: usize, end: usize) -> Self {
+        assert!(start <= end);
+        Self { start, end }
+    }
+}
+
+/// The `Mutation` struct represents a modification that was applied to a file.
+/// It contains the location of the modification, the name of the mutation operator, the old value and the new value.
+/// It is used to represent a single modification inside a `ReportEntry`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Mutation {
+    /// The location of the modification.
+    changed_place: Range,
+    /// The name of the mutation operator.
+    operator_name: String,
+    /// The old operator value.
+    old_value: String,
+    /// The new operator value.
+    new_value: String,
+}
+
+impl Mutation {
+    /// Creates a new `Mutation` instance.
+    pub fn new(
+        changed_place: Range,
+        operator_name: String,
+        old_value: String,
+        new_value: String,
+    ) -> Self {
+        Self {
+            changed_place,
+            operator_name,
+            old_value,
+            new_value,
+        }
+    }
+}
+
+/// The `MutationReport` struct represents an entry in a report.
+/// It contains information about a mutation that was applied to a file.
+#[derive(Debug, Clone, Serialize)]
+pub struct MutationReport {
+    /// The path to the mutated file.
+    mutant_path: PathBuf,
+    /// The path to the original file.
+    original_file: PathBuf,
+    /// The modifications that were applied to the file.
+    mutations: Vec<Mutation>,
+    /// The diff between the original and mutated file.
+    diff: String,
+}
+
+impl MutationReport {
+    /// Creates a new `MutationReport` instance.
+    /// Generates diff (patch) between the original and mutated source.
+    pub fn new(mutant_path: &Path, original_file: &Path, mutated_source: &str, original_source: &str ) -> Self {
+        let patch = diffy::create_patch(original_source, mutated_source);
+        Self {
+            mutant_path: mutant_path.to_path_buf(),
+            original_file: original_file.to_path_buf(),
+            mutations: vec![],
+            diff: patch.to_string(),
+        }
+    }
+
+    /// Adds a `Mutation` to the `MutationReport`.
+    pub fn add_modification(&mut self, modification: Mutation) {
+        self.mutations.push(modification);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Read;
+
+    #[test]
+    fn test_report() {
+        let mut report = Report::new();
+        assert_eq!(report.to_json().unwrap(), "{\n  \"mutants\": []\n}");
+
+        let range = Range::new(0, 10);
+        let modification = Mutation::new(
+            range,
+            "operator".to_string(),
+            "old".to_string(),
+            "new".to_string(),
+        );
+        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
+        report_entry.add_modification(modification);
+
+        report.add_entry(report_entry.clone());
+        assert_eq!(
+            report.to_json().unwrap(),
+            "{\n  \"mutants\": [\n    {\n      \"mutant_path\": \"file\",\n      \"original_file\": \"original_file\",\n      \"mutations\": [\n        {\n          \"changed_place\": {\n            \"start\": 0,\n            \"end\": 10\n          },\n          \"operator_name\": \"operator\",\n          \"old_value\": \"old\",\n          \"new_value\": \"new\"\n        }\n      ],\n      \"diff\": \"--- original\\n+++ modified\\n@@ -1 +1 @@\\n-diff\\n+\\n\"\n    }\n  ]\n}"
+        );
+    }
+
+    #[test]
+    fn test_range() {
+        let range = Range::new(0, 10);
+        assert_eq!(
+            serde_json::to_string(&range).unwrap(),
+            "{\"start\":0,\"end\":10}"
+        );
+    }
+
+    #[test]
+    fn test_modification() {
+        let range = Range::new(0, 10);
+        let modification = Mutation::new(
+            range,
+            "operator".to_string(),
+            "old".to_string(),
+            "new".to_string(),
+        );
+        assert_eq!(serde_json::to_string(&modification).unwrap(), "{\"changed_place\":{\"start\":0,\"end\":10},\"operator_name\":\"operator\",\"old_value\":\"old\",\"new_value\":\"new\"}");
+    }
+
+    #[test]
+    fn saves_report_as_text_file_successfully() {
+        let mut report = Report::new();
+        let range = Range::new(0, 10);
+        let modification = Mutation::new(
+            range,
+            "operator".to_string(),
+            "old".to_string(),
+            "new".to_string(),
+        );
+        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
+        report_entry.add_modification(modification);
+        report.add_entry(report_entry);
+
+        let path = Path::new("test_report.txt");
+        report.save_to_text_file(path).unwrap();
+
+        let mut file = fs::File::open(path).unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        assert!(contents.contains("Mutant path: file"));
+        assert!(contents.contains("Original file: original_file"));
+        assert!(contents.contains("Mutations:"));
+        assert!(contents.contains("Operator: operator"));
+        assert!(contents.contains("Old value: old"));
+        assert!(contents.contains("New value: new"));
+        assert!(contents.contains("Changed place: 0-10"));
+
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "No such file or directory")]
+    fn fails_to_save_report_to_non_existent_directory() {
+        let report = Report::new();
+        let path = Path::new("non_existent_directory/test_report.txt");
+        report.save_to_text_file(path).unwrap();
+    }
+}


### PR DESCRIPTION
### Description

This commit adds report generation. Report is stored in the output directory as a separate JSON file named `report.json` and as a plain text file called `report.txt`.
    
The text file is also stored as it's easier to view diffs in a text file than as a string inside a JSON field.
    
Reports contain information about all modifications done in each file. Reports handle single and multiple modifications inside one file (not yet supported by the `move-mutator`).

JSON report format sample:

```json
{
    "mutants": [
      {
        "mutant_path": "mutants_output/shift_0.move",
        "original_file": "third_party/move/move-prover/tests/sources/functional/shift.move",
        "mutations": [
          {
            "changed_place": {
              "start": 243,
              "end": 245
            },
            "operator_name": "BinaryOperator",
            "old_value": "<<",
            "new_value": ">>"
          }
        ],
        "diff": "--- original\n+++ modified\n@@ -5,7 +5,7 @@\n module 0x42::TestShift {\n\n     fun shiftl_1_correct(x: u64): u64 {\n-        x << 1\n+        x >> 1\n     }\n\n     spec shiftl_1_correct {\n"
      }
    ]
}
```

Text format sample:
```
Mutant path: mutants_output/shift_0.move
Original file: third_party/move/move-prover/tests/sources/functional/shift.move
Mutations:
  Operator: binary_operator_replacement
  Old value: <<
  New value: >>
  Changed place: 243-245
Diff:
--- original
+++ modified
@@ -5,7 +5,7 @@
 module 0x42::TestShift {

     fun shiftl_1_correct(x: u64): u64 {
-        x << 1
+        x >> 1
     }

     spec shiftl_1_correct {

----------------------------------------
```


### Test Plan
Unit tests for the `report` module.
Running the tests described in the `Readme.md` file and check reports.