### PR TITLE
feat: configuration file support

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -24,3 +24,6 @@ move-command-line-common = { path = "../../move-command-line-common" }
 move-compiler = { path = "../../move-compiler" }
 move-ir-types = { path = "../../move-ir/types" }
 move-package = { path = "../move-package" }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -12,7 +12,7 @@ cargo build -p move-cli
 
 Check if the tool is working properly by running its tests:
 ```bash
-cargo test -p move-mutator
+cargo test -p move-mutator -- --test-threads=1
 ```
 
 ## Usage

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -134,7 +134,7 @@ The last module in the main logic layer filters the mutants and reduces the outc
 
 This layer handles data sources - reading Move projects (source code) and configuration files. It also provides data to the other layers.
 
-The configuration file is a JSON file that contains the configuration of the Move mutator tool. It includes information on the project to mutate, mutation operators to use, mutation categories to use, and so on.
+The configuration file is a JSON or TOML (both supported) file that contains the configuration of the Move mutator tool. It includes information on the project to mutate, mutation operators to use, mutation categories to use, and so on.
 
 Sample configuration file:
 ```json

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -14,7 +14,7 @@ pub struct Options {
     pub exclude_files: Option<Vec<PathBuf>>,
     /// The path where to put the output files.
     pub output_dir: Option<PathBuf>,
-    /// Indicates if
+    /// Indicates if mutants should be verified and made sure mutants can compile.
     pub verify_mutants: Option<bool>,
     /// Indicates if the output files should be overwritten.
     pub no_overwrite: Option<bool>,

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Arg, Command};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 /// Command line options for mutator
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
@@ -7,21 +8,28 @@ use serde::{Deserialize, Serialize};
 pub struct Options {
     /// The paths to the Move sources.
     pub move_sources: Vec<String>,
+    /// The paths to the Move sources to include.
+    pub include_only_files: Option<Vec<PathBuf>>,
+    /// The paths to the Move sources to exclude.
+    pub exclude_files: Option<Vec<PathBuf>>,
+    /// The path where to put the output files.
+    pub output_dir: Option<PathBuf>,
+    /// Indicates if
+    pub verify_mutants: Option<bool>,
+    /// Indicates if the output files should be overwritten.
+    pub no_overwrite: Option<bool>,
+    /// Name of the filter to use for down sampling.
+    pub downsample_filter: Option<String>,
+    /// Optional configuration file. If provided, it will override the default configuration.
+    pub configuration_file: Option<PathBuf>,
+    /// Indicates if the output should be verbose.
+    pub verbose: Option<bool>,
 }
 
 impl Options {
-    /// Creates options from the TOML configuration source.
-    pub fn from_toml(toml_source: &str) -> anyhow::Result<Options> {
-        Ok(toml::from_str(toml_source)?)
-    }
-
-    /// Creates options from the TOML configuration file.
-    pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
-        Self::from_toml(&std::fs::read_to_string(toml_file)?)
-    }
-
     /// Creates Options struct from command line arguments.
     pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
+        //TODO: this code need to be updated to use clap parser directly
         let cli = Command::new("mutate")
             .version("0.1.0")
             .about("The Move Mutator")
@@ -64,35 +72,6 @@ impl Options {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
-    use std::path::Path;
-
-    #[test]
-    fn test_from_toml() {
-        let toml_str = r#"
-            move_sources = ["src/main.rs", "src/lib.rs"]
-        "#;
-
-        let options = Options::from_toml(toml_str).unwrap();
-        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
-    }
-
-    #[test]
-    fn test_from_toml_file() {
-        let toml_str = r#"
-            move_sources = ["src/main.rs", "src/lib.rs"]
-        "#;
-
-        let path = Path::new("test.toml");
-        let mut file = File::create(&path).unwrap();
-        file.write_all(toml_str.as_bytes()).unwrap();
-
-        let options = Options::from_toml_file(path.to_str().unwrap()).unwrap();
-        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
-
-        std::fs::remove_file(path).unwrap();
-    }
 
     #[test]
     fn test_create_from_args() {

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -3,6 +3,7 @@ use move_command_line_common::parser::NumberFormat;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use crate::configuration::Configuration;
 use move_compiler::diagnostics::FilesSourceText;
 use move_compiler::{
     command_line::compiler::*, diagnostics::unwrap_or_report_diagnostics, shared::Flags,
@@ -30,10 +31,12 @@ use move_package::BuildConfig;
 ///
 /// * `Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error>` - tuple of FilesSourceText and Program if successful, or an error if any error occurs.
 pub fn generate_ast(
-    source_files: Vec<String>,
+    mutator_configuration: &Configuration,
     config: BuildConfig,
     package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
+    let source_files = mutator_configuration.project.move_sources.clone();
+
     let named_addr_map = config
         .additional_named_addresses
         .into_iter()

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -31,11 +31,11 @@ use move_package::BuildConfig;
 ///
 /// * `Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error>` - tuple of FilesSourceText and Program if successful, or an error if any error occurs.
 pub fn generate_ast(
-    mutator_configuration: &Configuration,
+    mutator_config: &Configuration,
     config: BuildConfig,
     package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
-    let source_files = mutator_configuration.project.move_sources.clone();
+    let source_files = mutator_config.project.move_sources.clone();
 
     let named_addr_map = config
         .additional_named_addresses

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -1,0 +1,285 @@
+use crate::cli::Options;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Configuration file type
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum FileType {
+    JSON,
+    TOML,
+    Unknown,
+}
+
+/// Configuration for the project.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Configuration {
+    /// Main project options. It's the same as the CLI options.
+    pub project: Options,
+    /// Path to the project.
+    pub project_path: Option<PathBuf>,
+    /// Configuration for the mutation operators (project-wide).
+    pub mutation: Option<MutationsConfiguration>,
+    /// Configuration for the individual files. (optional)
+    pub individual: Option<Vec<IndividialConfiguration>>,
+}
+
+impl Configuration {
+    /// Creates a new configuration using command line options.
+    pub fn new(project: Options, project_path: Option<PathBuf>) -> Self {
+        Self {
+            project,
+            project_path,
+            mutation: None,
+            individual: None,
+        }
+    }
+
+    /// Recognizes the file type based on the file extension.
+    /// Currently supported file types are JSON and TOML.
+    pub fn recognize_file_type(file_path: &Path) -> FileType {
+        match file_path.extension().and_then(|s| s.to_str()) {
+            Some("json") => FileType::JSON,
+            Some("toml") => FileType::TOML,
+            _ => FileType::Unknown,
+        }
+    }
+
+    /// Reads configuration from the configuration file recognizing its type.
+    pub fn from_file(file_path: &Path) -> anyhow::Result<Configuration> {
+        let file_type = Configuration::recognize_file_type(file_path);
+        match file_type {
+            FileType::JSON => Configuration::from_json_file(file_path),
+            FileType::TOML => Configuration::from_toml_file(file_path),
+            _ => Err(anyhow::anyhow!("Unsupported file type")),
+        }
+    }
+
+    /// Reads configuration from the TOML configuration source.
+    pub fn from_toml(toml_source: &str) -> anyhow::Result<Configuration> {
+        Ok(toml::from_str(toml_source)?)
+    }
+
+    /// Reads configuration from the TOML configuration file.
+    pub fn from_toml_file(toml_file: &Path) -> anyhow::Result<Configuration> {
+        Self::from_toml(&std::fs::read_to_string(toml_file)?)
+    }
+
+    /// Reads configuration from the JSON configuration source.
+    pub fn from_json_file(json_file: &Path) -> anyhow::Result<Configuration> {
+        Ok(serde_json::from_str(&std::fs::read_to_string(json_file)?)?)
+    }
+}
+
+/// Configuration of the mutation operators.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MutationsConfiguration {
+    /// Names of the mutation operators to use. If not provided, all operators will be used.
+    pub operators: Vec<String>,
+    /// Names of the mutation categories to be used..
+    pub categories: Vec<String>,
+}
+
+/// Configuration for the individual file.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndividialConfiguration {
+    /// The path to the Move source.
+    pub file: PathBuf,
+    /// Indicates if the mutants should be verified
+    pub verify_mutants: Option<bool>,
+    /// Names of the mutation operators to use. If not provided, all operators will be used.
+    pub mutation_operators: Option<MutationsConfiguration>,
+    /// Mutate only the functions with the given names.
+    pub include_functions: Option<Vec<String>>,
+    /// Mutate all functions except the ones with the given names.
+    pub exclude_functions: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn configuration_from_toml_file_loads_correctly() {
+        let toml_content = r#"
+            [project]
+            move_sources = ["/path/to/move/source"]
+            [mutation]
+            operators = ["operator1", "operator2"]
+            categories = ["category1", "category2"]
+            [[individual]]
+            file = "/path/to/file"
+            verify_mutants = true
+            include_functions = ["function1", "function2"]
+            exclude_functions = ["function3", "function4"]
+        "#;
+        fs::write("test.toml", toml_content).unwrap();
+        let config = Configuration::from_toml_file(Path::new("test.toml")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(
+            config.mutation.unwrap().operators,
+            vec!["operator1", "operator2"]
+        );
+        fs::remove_file("test.toml").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_non_existent_toml_file_fails() {
+        let result = Configuration::from_toml_file(Path::new("non_existent.toml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn configuration_from_invalid_toml_file_fails() {
+        let toml_content = r#"
+            [project]
+            move_sources = "/path/to/move/source"
+        "#;
+        fs::write("test.toml", toml_content).unwrap();
+        let result = Configuration::from_toml_file(Path::new("test.toml"));
+        assert!(result.is_err());
+        fs::remove_file("test.toml").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_json_file_loads_correctly() {
+        let json_content = r#"
+            {
+                "project": {
+                    "move_sources": ["/path/to/move/source"],
+                    "include_only_files": ["/path/to/include/file"],
+                    "exclude_files": ["/path/to/exclude/file"],
+                    "output_dir": "/path/to/output",
+                    "verify_mutants": true,
+                    "no_overwrite": false,
+                    "downsample_filter": "filter",
+                    "configuration_file": "/path/to/configuration"
+                },
+                "project_path": "/path/to/project",
+                "mutation": {
+                    "operators": ["operator1", "operator2"],
+                    "categories": ["category1", "category2"]
+                },
+                "individual": [
+                    {
+                        "file": "/path/to/file",
+                        "verify_mutants": true,
+                        "mutation_operators": {
+                            "operators": ["operator3", "operator4"],
+                            "categories": ["category3", "category4"]
+                        },
+                        "include_functions": ["function1", "function2"],
+                        "exclude_functions": ["function3", "function4"]
+                    }
+                ]
+            }
+        "#;
+        fs::write("test.json", json_content).unwrap();
+        let config = Configuration::from_json_file(Path::new("test.json")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(
+            config.project.include_only_files.unwrap(),
+            vec![Path::new("/path/to/include/file")]
+        );
+        assert_eq!(
+            config.project.exclude_files.unwrap(),
+            vec![Path::new("/path/to/exclude/file")]
+        );
+        assert_eq!(
+            config.project.output_dir.unwrap(),
+            Path::new("/path/to/output")
+        );
+        assert_eq!(config.project.verify_mutants.unwrap(), true);
+        assert_eq!(config.project.no_overwrite.unwrap(), false);
+        assert_eq!(config.project.downsample_filter.unwrap(), "filter");
+        assert_eq!(
+            config.project.configuration_file.unwrap(),
+            Path::new("/path/to/configuration")
+        );
+        assert_eq!(config.project_path.unwrap(), Path::new("/path/to/project"));
+        assert_eq!(
+            config.mutation.unwrap().operators,
+            vec!["operator1", "operator2"]
+        );
+        fs::remove_file("test.json").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_non_existent_json_file_fails() {
+        let result = Configuration::from_json_file(Path::new("non_existent.json"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn configuration_from_invalid_json_file_fails() {
+        let json_content = r#"
+            {
+                "project": {
+                    "move_sources": "/path/to/move/source"
+                }
+            }
+        "#;
+        fs::write("test.json", json_content).unwrap();
+        let result = Configuration::from_json_file(Path::new("test.json"));
+        assert!(result.is_err());
+        fs::remove_file("test.json").unwrap();
+    }
+
+    #[test]
+    fn recognizes_json_file_type_correctly() {
+        assert_eq!(
+            Configuration::recognize_file_type(Path::new("test.json")),
+            FileType::JSON
+        );
+    }
+
+    #[test]
+    fn recognizes_toml_file_type_correctly() {
+        assert_eq!(
+            Configuration::recognize_file_type(Path::new("test.toml")),
+            FileType::TOML
+        );
+    }
+
+    #[test]
+    fn recognizes_unknown_file_type_correctly() {
+        assert_eq!(
+            Configuration::recognize_file_type(Path::new("test.unknown")),
+            FileType::Unknown
+        );
+    }
+
+    #[test]
+    fn configuration_from_file_loads_json_correctly() {
+        let json_content = r#"
+            {
+                "project": {
+                    "move_sources": ["/path/to/move/source"]
+                }
+            }
+        "#;
+        fs::write("test.json", json_content).unwrap();
+        let config = Configuration::from_file(Path::new("test.json")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        fs::remove_file("test.json").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_file_loads_toml_correctly() {
+        let toml_content = r#"
+            [project]
+            move_sources = ["/path/to/move/source"]
+        "#;
+        fs::write("test.toml", toml_content).unwrap();
+        let config = Configuration::from_file(Path::new("test.toml")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        fs::remove_file("test.toml").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_file_fails_for_unknown_file_type() {
+        let result = Configuration::from_file(Path::new("test.unknown"));
+        assert!(result.is_err());
+    }
+}

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -52,14 +52,10 @@ impl Configuration {
         }
     }
 
-    /// Reads configuration from the TOML configuration source.
-    fn from_toml(toml_source: &str) -> anyhow::Result<Configuration> {
-        Ok(toml::from_str(toml_source)?)
-    }
-
     /// Reads configuration from the TOML configuration file.
     pub fn from_toml_file(toml_file: &Path) -> anyhow::Result<Configuration> {
-        Self::from_toml(&std::fs::read_to_string(toml_file)?)
+        let toml_source = std::fs::read_to_string(toml_file)?;
+        Ok(toml::from_str(toml_source.as_str())?)
     }
 
     /// Reads configuration from the JSON configuration source.

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -17,7 +17,7 @@ pub struct Configuration {
     /// Path to the project.
     pub project_path: Option<PathBuf>,
     /// Configuration for the mutation operators (project-wide).
-    pub mutation: Option<MutationsConfiguration>,
+    pub mutation: Option<MutationConfig>,
     /// Configuration for the individual files. (optional)
     pub individual: Option<Vec<FileConfiguration>>,
 }
@@ -35,7 +35,7 @@ impl Configuration {
 
     /// Recognizes the file type based on the file extension.
     /// Currently supported file types are JSON and TOML.
-    pub fn recognize_file_type(file_path: &Path) -> anyhow::Result<FileType> {
+    fn get_file_type(file_path: &Path) -> anyhow::Result<FileType> {
         match file_path.extension().and_then(|s| s.to_str()) {
             Some("json") => Ok(FileType::JSON),
             Some("toml") => Ok(FileType::TOML),
@@ -45,7 +45,7 @@ impl Configuration {
 
     /// Reads configuration from the configuration file recognizing its type.
     pub fn from_file(file_path: &Path) -> anyhow::Result<Configuration> {
-        let file_type = Configuration::recognize_file_type(file_path)?;
+        let file_type = Configuration::get_file_type(file_path)?;
         match file_type {
             FileType::JSON => Configuration::from_json_file(file_path),
             FileType::TOML => Configuration::from_toml_file(file_path),
@@ -53,7 +53,7 @@ impl Configuration {
     }
 
     /// Reads configuration from the TOML configuration source.
-    pub fn from_toml(toml_source: &str) -> anyhow::Result<Configuration> {
+    fn from_toml(toml_source: &str) -> anyhow::Result<Configuration> {
         Ok(toml::from_str(toml_source)?)
     }
 
@@ -70,10 +70,10 @@ impl Configuration {
 
 /// Configuration of the mutation operators.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct MutationsConfiguration {
+pub struct MutationConfig {
     /// Names of the mutation operators to use. If not provided, all operators will be used.
     pub operators: Vec<String>,
-    /// Names of the mutation categories to be used..
+    /// Names of the mutation categories to be used.
     pub categories: Vec<String>,
 }
 
@@ -85,7 +85,7 @@ pub struct FileConfiguration {
     /// Indicates if the mutants should be verified
     pub verify_mutants: Option<bool>,
     /// Names of the mutation operators to use. If not provided, all operators will be used.
-    pub mutation_operators: Option<MutationsConfiguration>,
+    pub mutation_operators: Option<MutationConfig>,
     /// Mutate only the functions with the given names.
     pub include_functions: Option<Vec<String>>,
     /// Mutate all functions except the ones with the given names.
@@ -227,7 +227,7 @@ mod tests {
     #[test]
     fn recognizes_json_file_type_correctly() {
         assert_eq!(
-            Configuration::recognize_file_type(Path::new("test.json")).unwrap(),
+            Configuration::get_file_type(Path::new("test.json")).unwrap(),
             FileType::JSON
         );
     }
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn recognizes_toml_file_type_correctly() {
         assert_eq!(
-            Configuration::recognize_file_type(Path::new("test.toml")).unwrap(),
+            Configuration::get_file_type(Path::new("test.toml")).unwrap(),
             FileType::TOML
         );
     }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -48,6 +48,7 @@ pub fn run_move_mutator(
         let file_name = path.file_stem().unwrap().to_str().unwrap();
 
         // Check if file is not excluded from mutant generation
+        //TODO(asmie): refactor this when proper filtering will be introduced in the M3
         if let Some(excluded) = mutator_configuration.project.exclude_files.as_ref() {
             if excluded.contains(&path.to_path_buf()) {
                 continue;

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -138,7 +138,12 @@ pub struct MutationReport {
 impl MutationReport {
     /// Creates a new `MutationReport` instance.
     /// Generates diff (patch) between the original and mutated source.
-    pub fn new(mutant_path: &Path, original_file: &Path, mutated_source: &str, original_source: &str ) -> Self {
+    pub fn new(
+        mutant_path: &Path,
+        original_file: &Path,
+        mutated_source: &str,
+        original_source: &str,
+    ) -> Self {
         let patch = diffy::create_patch(original_source, mutated_source);
         Self {
             mutant_path: mutant_path.to_path_buf(),
@@ -172,7 +177,12 @@ mod tests {
             "old".to_string(),
             "new".to_string(),
         );
-        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
+        let mut report_entry = MutationReport::new(
+            Path::new("file"),
+            Path::new("original_file"),
+            "\n",
+            "diff\n",
+        );
         report_entry.add_modification(modification);
 
         report.add_entry(report_entry.clone());
@@ -213,7 +223,12 @@ mod tests {
             "old".to_string(),
             "new".to_string(),
         );
-        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
+        let mut report_entry = MutationReport::new(
+            Path::new("file"),
+            Path::new("original_file"),
+            "\n",
+            "diff\n",
+        );
         report_entry.add_modification(modification);
         report.add_entry(report_entry);
 


### PR DESCRIPTION
### Description

This PR introduces usage of new configuration file. For now, it's used for general settings, reporting and compilation things.

Using it for other things (like selecting mutation operators) will be done in the next milestone, as mutation operators demand refactoring.

### Test Plan
Unit tests for the configuration file facility.
