### PR TITLE
[move-mutator] configuration file support

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -24,3 +24,6 @@ move-command-line-common = { path = "../../move-command-line-common" }
 move-compiler = { path = "../../move-compiler" }
 move-ir-types = { path = "../../move-ir/types" }
 move-package = { path = "../move-package" }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -12,7 +12,7 @@ cargo build -p move-cli
 
 Check if the tool is working properly by running its tests:
 ```bash
-cargo test -p move-mutator
+cargo test -p move-mutator -- --test-threads=1
 ```
 
 ## Usage

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -134,7 +134,7 @@ The last module in the main logic layer filters the mutants and reduces the outc
 
 This layer handles data sources - reading Move projects (source code) and configuration files. It also provides data to the other layers.
 
-The configuration file is a JSON file that contains the configuration of the Move mutator tool. It includes information on the project to mutate, mutation operators to use, mutation categories to use, and so on.
+The configuration file is a JSON or TOML (both supported) file that contains the configuration of the Move mutator tool. It includes information on the project to mutate, mutation operators to use, mutation categories to use, and so on.
 
 Sample configuration file:
 ```json

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Arg, Command};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 /// Command line options for mutator
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
@@ -7,21 +8,28 @@ use serde::{Deserialize, Serialize};
 pub struct Options {
     /// The paths to the Move sources.
     pub move_sources: Vec<String>,
+    /// The paths to the Move sources to include.
+    pub include_only_files: Option<Vec<PathBuf>>,
+    /// The paths to the Move sources to exclude.
+    pub exclude_files: Option<Vec<PathBuf>>,
+    /// The path where to put the output files.
+    pub output_dir: Option<PathBuf>,
+    /// Indicates if mutants should be verified and made sure mutants can compile.
+    pub verify_mutants: Option<bool>,
+    /// Indicates if the output files should be overwritten.
+    pub no_overwrite: Option<bool>,
+    /// Name of the filter to use for down sampling.
+    pub downsample_filter: Option<String>,
+    /// Optional configuration file. If provided, it will override the default configuration.
+    pub configuration_file: Option<PathBuf>,
+    /// Indicates if the output should be verbose.
+    pub verbose: Option<bool>,
 }
 
 impl Options {
-    /// Creates options from the TOML configuration source.
-    pub fn from_toml(toml_source: &str) -> anyhow::Result<Options> {
-        Ok(toml::from_str(toml_source)?)
-    }
-
-    /// Creates options from the TOML configuration file.
-    pub fn from_toml_file(toml_file: &str) -> anyhow::Result<Options> {
-        Self::from_toml(&std::fs::read_to_string(toml_file)?)
-    }
-
     /// Creates Options struct from command line arguments.
     pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
+        //TODO: this code need to be updated to use clap parser directly
         let cli = Command::new("mutate")
             .version("0.1.0")
             .about("The Move Mutator")
@@ -64,35 +72,6 @@ impl Options {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
-    use std::path::Path;
-
-    #[test]
-    fn test_from_toml() {
-        let toml_str = r#"
-            move_sources = ["src/main.rs", "src/lib.rs"]
-        "#;
-
-        let options = Options::from_toml(toml_str).unwrap();
-        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
-    }
-
-    #[test]
-    fn test_from_toml_file() {
-        let toml_str = r#"
-            move_sources = ["src/main.rs", "src/lib.rs"]
-        "#;
-
-        let path = Path::new("test.toml");
-        let mut file = File::create(&path).unwrap();
-        file.write_all(toml_str.as_bytes()).unwrap();
-
-        let options = Options::from_toml_file(path.to_str().unwrap()).unwrap();
-        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
-
-        std::fs::remove_file(path).unwrap();
-    }
 
     #[test]
     fn test_create_from_args() {

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -3,6 +3,7 @@ use move_command_line_common::parser::NumberFormat;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use crate::configuration::Configuration;
 use move_compiler::diagnostics::FilesSourceText;
 use move_compiler::{
     command_line::compiler::*, diagnostics::unwrap_or_report_diagnostics, shared::Flags,
@@ -30,10 +31,12 @@ use move_package::BuildConfig;
 ///
 /// * `Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error>` - tuple of FilesSourceText and Program if successful, or an error if any error occurs.
 pub fn generate_ast(
-    source_files: Vec<String>,
+    mutator_config: &Configuration,
     config: BuildConfig,
     package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
+    let source_files = mutator_config.project.move_sources.clone();
+
     let named_addr_map = config
         .additional_named_addresses
         .into_iter()

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -1,0 +1,271 @@
+use crate::cli::Options;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Configuration file type.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum FileType {
+    JSON,
+    TOML,
+}
+
+/// Mutator configuration for the Move project.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Configuration {
+    /// Main project options. It's the same as the CLI options.
+    pub project: Options,
+    /// Path to the project.
+    pub project_path: Option<PathBuf>,
+    /// Configuration for the mutation operators (project-wide).
+    pub mutation: Option<MutationConfig>,
+    /// Configuration for the individual files. (optional)
+    pub individual: Option<Vec<FileConfiguration>>,
+}
+
+impl Configuration {
+    /// Creates a new configuration using command line options.
+    pub fn new(project: Options, project_path: Option<PathBuf>) -> Self {
+        Self {
+            project,
+            project_path,
+            mutation: None,
+            individual: None,
+        }
+    }
+
+    /// Recognizes the file type based on the file extension.
+    /// Currently supported file types are JSON and TOML.
+    fn get_file_type(file_path: &Path) -> anyhow::Result<FileType> {
+        match file_path.extension().and_then(|s| s.to_str()) {
+            Some("json") => Ok(FileType::JSON),
+            Some("toml") => Ok(FileType::TOML),
+            _ => Err(anyhow::anyhow!("Unsupported file type")),
+        }
+    }
+
+    /// Reads configuration from the configuration file recognizing its type.
+    pub fn from_file(file_path: &Path) -> anyhow::Result<Configuration> {
+        let file_type = Configuration::get_file_type(file_path)?;
+        match file_type {
+            FileType::JSON => Configuration::from_json_file(file_path),
+            FileType::TOML => Configuration::from_toml_file(file_path),
+        }
+    }
+
+    /// Reads configuration from the TOML configuration file.
+    pub fn from_toml_file(toml_file: &Path) -> anyhow::Result<Configuration> {
+        let toml_source = std::fs::read_to_string(toml_file)?;
+        Ok(toml::from_str(toml_source.as_str())?)
+    }
+
+    /// Reads configuration from the JSON configuration source.
+    pub fn from_json_file(json_file: &Path) -> anyhow::Result<Configuration> {
+        Ok(serde_json::from_str(&std::fs::read_to_string(json_file)?)?)
+    }
+}
+
+/// Configuration of the mutation operators.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MutationConfig {
+    /// Names of the mutation operators to use. If not provided, all operators will be used.
+    pub operators: Vec<String>,
+    /// Names of the mutation categories to be used.
+    pub categories: Vec<String>,
+}
+
+/// Configuration for the individual file.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FileConfiguration {
+    /// The path to the Move source.
+    pub file: PathBuf,
+    /// Indicates if the mutants should be verified
+    pub verify_mutants: Option<bool>,
+    /// Names of the mutation operators to use. If not provided, all operators will be used.
+    pub mutation_operators: Option<MutationConfig>,
+    /// Mutate only the functions with the given names.
+    pub include_functions: Option<Vec<String>>,
+    /// Mutate all functions except the ones with the given names.
+    pub exclude_functions: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn configuration_from_toml_file_loads_correctly() {
+        let toml_content = r#"
+            [project]
+            move_sources = ["/path/to/move/source"]
+            [mutation]
+            operators = ["operator1", "operator2"]
+            categories = ["category1", "category2"]
+            [[individual]]
+            file = "/path/to/file"
+            verify_mutants = true
+            include_functions = ["function1", "function2"]
+            exclude_functions = ["function3", "function4"]
+        "#;
+        fs::write("test.toml", toml_content).unwrap();
+        let config = Configuration::from_toml_file(Path::new("test.toml")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(
+            config.mutation.unwrap().operators,
+            vec!["operator1", "operator2"]
+        );
+        fs::remove_file("test.toml").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_non_existent_toml_file_fails() {
+        let result = Configuration::from_toml_file(Path::new("non_existent.toml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn configuration_from_invalid_toml_file_fails() {
+        let toml_content = r#"
+            [project]
+            move_sources = "/path/to/move/source"
+        "#;
+        fs::write("test.toml", toml_content).unwrap();
+        let result = Configuration::from_toml_file(Path::new("test.toml"));
+        assert!(result.is_err());
+        fs::remove_file("test.toml").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_json_file_loads_correctly() {
+        let json_content = r#"
+            {
+                "project": {
+                    "move_sources": ["/path/to/move/source"],
+                    "include_only_files": ["/path/to/include/file"],
+                    "exclude_files": ["/path/to/exclude/file"],
+                    "output_dir": "/path/to/output",
+                    "verify_mutants": true,
+                    "no_overwrite": false,
+                    "downsample_filter": "filter",
+                    "configuration_file": "/path/to/configuration"
+                },
+                "project_path": "/path/to/project",
+                "mutation": {
+                    "operators": ["operator1", "operator2"],
+                    "categories": ["category1", "category2"]
+                },
+                "individual": [
+                    {
+                        "file": "/path/to/file",
+                        "verify_mutants": true,
+                        "mutation_operators": {
+                            "operators": ["operator3", "operator4"],
+                            "categories": ["category3", "category4"]
+                        },
+                        "include_functions": ["function1", "function2"],
+                        "exclude_functions": ["function3", "function4"]
+                    }
+                ]
+            }
+        "#;
+        fs::write("test.json", json_content).unwrap();
+        let config = Configuration::from_json_file(Path::new("test.json")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(
+            config.project.include_only_files.unwrap(),
+            vec![Path::new("/path/to/include/file")]
+        );
+        assert_eq!(
+            config.project.exclude_files.unwrap(),
+            vec![Path::new("/path/to/exclude/file")]
+        );
+        assert_eq!(
+            config.project.output_dir.unwrap(),
+            Path::new("/path/to/output")
+        );
+        assert_eq!(config.project.verify_mutants.unwrap(), true);
+        assert_eq!(config.project.no_overwrite.unwrap(), false);
+        assert_eq!(config.project.downsample_filter.unwrap(), "filter");
+        assert_eq!(
+            config.project.configuration_file.unwrap(),
+            Path::new("/path/to/configuration")
+        );
+        assert_eq!(config.project_path.unwrap(), Path::new("/path/to/project"));
+        assert_eq!(
+            config.mutation.unwrap().operators,
+            vec!["operator1", "operator2"]
+        );
+        fs::remove_file("test.json").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_non_existent_json_file_fails() {
+        let result = Configuration::from_json_file(Path::new("non_existent.json"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn configuration_from_invalid_json_file_fails() {
+        let json_content = r#"
+            {
+                "project": {
+                    "move_sources": "/path/to/move/source"
+                }
+            }
+        "#;
+        fs::write("test.json", json_content).unwrap();
+        let result = Configuration::from_json_file(Path::new("test.json"));
+        assert!(result.is_err());
+        fs::remove_file("test.json").unwrap();
+    }
+
+    #[test]
+    fn recognizes_json_file_type_correctly() {
+        assert_eq!(
+            Configuration::get_file_type(Path::new("test.json")).unwrap(),
+            FileType::JSON
+        );
+    }
+
+    #[test]
+    fn recognizes_toml_file_type_correctly() {
+        assert_eq!(
+            Configuration::get_file_type(Path::new("test.toml")).unwrap(),
+            FileType::TOML
+        );
+    }
+
+    #[test]
+    fn configuration_from_file_loads_json_correctly() {
+        let json_content = r#"
+            {
+                "project": {
+                    "move_sources": ["/path/to/move/source"]
+                }
+            }
+        "#;
+        fs::write("test.json", json_content).unwrap();
+        let config = Configuration::from_file(Path::new("test.json")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        fs::remove_file("test.json").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_file_loads_toml_correctly() {
+        let toml_content = r#"
+            [project]
+            move_sources = ["/path/to/move/source"]
+        "#;
+        fs::write("test.toml", toml_content).unwrap();
+        let config = Configuration::from_file(Path::new("test.toml")).unwrap();
+        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        fs::remove_file("test.toml").unwrap();
+    }
+
+    #[test]
+    fn configuration_from_file_fails_for_unknown_file_type() {
+        let result = Configuration::from_file(Path::new("test.unknown"));
+        assert!(result.is_err());
+    }
+}

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -3,6 +3,7 @@ mod compiler;
 
 mod mutate;
 
+mod configuration;
 mod mutant;
 mod operator;
 mod report;
@@ -10,11 +11,12 @@ mod report;
 use crate::compiler::generate_ast;
 use std::path::Path;
 
+use crate::configuration::Configuration;
 use crate::report::Report;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
-const OUTPUT_DIR: &str = "mutants_output";
+const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
 
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.
@@ -28,12 +30,16 @@ pub fn run_move_mutator(
         options, config, package_path
     );
 
-    let (files, ast) = generate_ast(options.move_sources, config, package_path)?;
+    let mutator_configuration = match options.configuration_file {
+        Some(path) => configuration::Configuration::from_file(path.as_path())?,
+        None => configuration::Configuration::new(options, Some(package_path.clone())),
+    };
+
+    let (files, ast) = generate_ast(&mutator_configuration, config, package_path)?;
 
     let mutants = mutate::mutate(ast)?;
 
-    let _ = std::fs::remove_dir_all(OUTPUT_DIR);
-    std::fs::create_dir(OUTPUT_DIR)?;
+    let output_dir = setup_output_dir(&mutator_configuration)?;
 
     let mut report: Report = Report::new();
 
@@ -41,18 +47,39 @@ pub fn run_move_mutator(
         let path = Path::new(filename.as_str());
         let file_name = path.file_stem().unwrap().to_str().unwrap();
 
+        // Check if file is not excluded from mutant generation
+        //TODO(asmie): refactor this when proper filtering will be introduced in the M3
+        if let Some(excluded) = mutator_configuration.project.exclude_files.as_ref() {
+            if excluded.contains(&path.to_path_buf()) {
+                continue;
+            }
+        }
+
+        // Check if file is explicitly included in mutant generation (if include_only_files is set)
+        if let Some(included) = mutator_configuration.project.include_only_files.as_ref() {
+            if !included.contains(&path.to_path_buf()) {
+                continue;
+            }
+        }
+
         let mut i = 0;
         for mutant in mutants.iter().filter(|m| m.get_file_hash() == hash) {
             let mutated_sources = mutant.apply(&source);
             for mutated in mutated_sources {
-                let mutant_path = PathBuf::from(format!("mutants_output/{}_{}.move", file_name, i));
+                let mutant_path = setup_mutant_path(&output_dir, file_name, i);
+
                 println!(
                     "{} written to {}",
                     mutant,
                     mutant_path.to_str().unwrap_or("")
                 );
                 std::fs::write(&mutant_path, &mutated.mutated_source)?;
-                let mut entry = report::MutationReport::new(mutant_path.as_path(), path, &mutated.mutated_source, &source);
+                let mut entry = report::MutationReport::new(
+                    mutant_path.as_path(),
+                    path,
+                    &mutated.mutated_source,
+                    &source,
+                );
                 entry.add_modification(mutated.mutation);
                 report.add_entry(entry);
                 i += 1;
@@ -60,8 +87,121 @@ pub fn run_move_mutator(
         }
     }
 
-    report.save_to_json_file(Path::new("mutants_output/report.json"))?;
-    report.save_to_text_file(Path::new("mutants_output/report.txt"))?;
+    let report_path = PathBuf::from(output_dir);
+
+    report.save_to_json_file(report_path.join(Path::new("report.json")).as_path())?;
+    report.save_to_text_file(report_path.join(Path::new("report.txt")).as_path())?;
 
     Ok(())
+}
+
+/// Sets up the path for the mutant.
+#[inline]
+fn setup_mutant_path(output_dir: &Path, filename: &str, index: u64) -> PathBuf {
+    PathBuf::from(format!(
+        "{}/{}_{}.move",
+        &output_dir.to_str().unwrap_or(DEFAULT_OUTPUT_DIR),
+        filename,
+        index
+    ))
+}
+
+/// Sets up the output directory for the mutants.
+fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow::Result<PathBuf> {
+    let output_dir = mutator_configuration
+        .project
+        .output_dir
+        .clone()
+        .unwrap_or(PathBuf::from(DEFAULT_OUTPUT_DIR));
+
+    // Check if output directory exists and if it should be overwritten
+    if output_dir.exists() && mutator_configuration.project.no_overwrite.unwrap_or(false) {
+        return Err(anyhow::anyhow!(
+            "Output directory already exists. Use --no-overwrite=false to overwrite."
+        ));
+    }
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+    std::fs::create_dir(&output_dir)?;
+
+    Ok(output_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn setup_mutant_path_creates_correct_path() {
+        let output_dir = Path::new("/path/to/output");
+        let filename = "test";
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        assert_eq!(result, PathBuf::from("/path/to/output/test_1.move"));
+    }
+
+    #[test]
+    fn setup_mutant_path_handles_empty_output_dir() {
+        let output_dir = Path::new("");
+        let filename = "test";
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        assert_eq!(result, PathBuf::from("/test_1.move"));
+    }
+
+    #[test]
+    fn setup_mutant_path_handles_empty_filename() {
+        let output_dir = Path::new("/path/to/output");
+        let filename = "";
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        assert_eq!(result, PathBuf::from("/path/to/output/_1.move"));
+    }
+
+    #[test]
+    fn setup_output_dir_creates_directory_if_not_exists() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        let options = cli::Options {
+            output_dir: Some(output_dir.clone()),
+            no_overwrite: Some(false),
+            ..Default::default()
+        };
+        let config = Configuration::new(options, None);
+        assert!(setup_output_dir(&config).is_ok());
+        assert!(output_dir.exists());
+    }
+
+    #[test]
+    fn setup_output_dir_overwrites_directory_if_exists_and_no_overwrite_is_false() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        fs::create_dir(&output_dir).unwrap();
+        let options = cli::Options {
+            output_dir: Some(output_dir.clone()),
+            no_overwrite: Some(false),
+            ..Default::default()
+        };
+        let config = Configuration::new(options, None);
+        assert!(setup_output_dir(&config).is_ok());
+        assert!(output_dir.exists());
+    }
+
+    #[test]
+    fn setup_output_dir_errors_if_directory_exists_and_no_overwrite_is_true() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        fs::create_dir(&output_dir).unwrap();
+        let options = cli::Options {
+            output_dir: Some(output_dir.clone()),
+            no_overwrite: Some(true),
+            ..Default::default()
+        };
+        let config = Configuration::new(options, None);
+        assert!(setup_output_dir(&config).is_err());
+    }
 }

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -138,7 +138,12 @@ pub struct MutationReport {
 impl MutationReport {
     /// Creates a new `MutationReport` instance.
     /// Generates diff (patch) between the original and mutated source.
-    pub fn new(mutant_path: &Path, original_file: &Path, mutated_source: &str, original_source: &str ) -> Self {
+    pub fn new(
+        mutant_path: &Path,
+        original_file: &Path,
+        mutated_source: &str,
+        original_source: &str,
+    ) -> Self {
         let patch = diffy::create_patch(original_source, mutated_source);
         Self {
             mutant_path: mutant_path.to_path_buf(),
@@ -172,7 +177,12 @@ mod tests {
             "old".to_string(),
             "new".to_string(),
         );
-        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
+        let mut report_entry = MutationReport::new(
+            Path::new("file"),
+            Path::new("original_file"),
+            "\n",
+            "diff\n",
+        );
         report_entry.add_modification(modification);
 
         report.add_entry(report_entry.clone());
@@ -213,7 +223,12 @@ mod tests {
             "old".to_string(),
             "new".to_string(),
         );
-        let mut report_entry = MutationReport::new(Path::new("file"), Path::new("original_file"), "\n", "diff\n");
+        let mut report_entry = MutationReport::new(
+            Path::new("file"),
+            Path::new("original_file"),
+            "\n",
+            "diff\n",
+        );
         report_entry.add_modification(modification);
         report.add_entry(report_entry);
 


### PR DESCRIPTION
### Description

This PR introduces usage of new configuration file.

Configuration file format:
```
{
                "project": {
                    "move_sources": ["/path/to/move/source"],
                    "include_only_files": ["/path/to/include/file"],
                    "exclude_files": ["/path/to/exclude/file"],
                    "output_dir": "/path/to/output",
                    "verify_mutants": true,
                    "no_overwrite": false,
                    "downsample_filter": "filter",
                    "configuration_file": "/path/to/configuration"
                },
                "project_path": "/path/to/project",
                "mutation": {
                    "operators": ["operator1", "operator2"],
                    "categories": ["category1", "category2"]
                },
                "individual": [
                    {
                        "file": "/path/to/file",
                        "verify_mutants": true,
                        "mutation_operators": {
                            "operators": ["operator3", "operator4"],
                            "categories": ["category3", "category4"]
                        },
                        "include_functions": ["function1", "function2"],
                        "exclude_functions": ["function3", "function4"]
                    }
                ]
            }
```

There is possibility to use TOML format. User can pass file in either format, it will be recognized by the extension.

For now, it's used for general settings, reporting and compilation things.

Using it for other things (like selecting mutation operators) will be done in the next milestone, as mutation operators demand refactoring.

### Test Plan
Unit tests for the `configuration` module.
