### PR TITLE
[move-mutator] CLI integration

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -519,15 +519,7 @@ pub struct MutatePackage {
     move_options: MovePackageDir,
     /// Options specific for the mutator tool
     #[clap(flatten)]
-    mutator_options: MutatorOptions,
-}
-
-/// Move mutator tool options
-#[derive(Parser)]
-pub struct MutatorOptions {
-    /// Move source files to mutate (paths)
-    #[clap(long, short)]
-    pub move_sources: Vec<String>,
+    mutator_options: Option<move_mutator::cli::Options>,
 }
 
 #[async_trait]
@@ -564,9 +556,7 @@ impl CliCommand<&'static str> for MutatePackage {
         let path = self.move_options.get_package_path()?;
 
         let result = move_mutator::run_move_mutator(
-            move_mutator::cli::Options {
-                move_sources: mutator_options.move_sources,
-            },
+            mutator_options.unwrap_or_default(),
             config,
             path,
         )

--- a/third_party/move/tools/move-cli/src/base/mutate.rs
+++ b/third_party/move/tools/move-cli/src/base/mutate.rs
@@ -2,26 +2,13 @@ use clap::*;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
-/// Move mutator-specific options.
-#[derive(Parser, Debug)]
-pub enum MutatorOptions {
-    // Pass through unknown commands to the mutator Clap parser
-    #[clap(
-        external_subcommand,
-        takes_value(true),
-        multiple_values(true),
-        multiple_occurrences(true)
-    )]
-    Options(Vec<String>),
-}
-
 /// Mutate the Move files or package
 #[derive(Parser)]
 #[clap(name = "mutate")]
 pub struct Mutate {
     /// Any options passed to the move-mutator
-    #[clap(subcommand)]
-    pub options: Option<MutatorOptions>,
+    #[clap(flatten)]
+    pub options: Option<move_mutator::cli::Options>,
 }
 
 impl Mutate {
@@ -33,12 +20,8 @@ impl Mutate {
 
         let Self { options } = self;
 
-        let opts = match options {
-            Some(MutatorOptions::Options(opts)) => opts,
-            _ => vec![],
-        };
+        let options = options.unwrap_or_default();
 
-        let options = move_mutator::cli::Options::create_from_args(&opts)?;
         move_mutator::run_move_mutator(options, config, path)
     }
 }

--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -14,8 +14,8 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = "1.0"
-diffy = "0.3"
 clap = { version = "4.3", features = ["derive"] }
+diffy = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -19,32 +19,41 @@ cargo test -p move-mutator -- --test-threads=1
 
 To check if it works, run the following command:
 ```bash
-./target/debug/move mutate sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+./target/debug/move mutate -m third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
 ```
 
 or
 
 ```bash
-./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+./target/debug/aptos move mutate -m third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
 ```
 
-The output will be generated under the `mutants_output` directory.
+The output will be generated under the `mutants_output` (or any other selected) directory.
+
+To check possible options run:
+```bash
+./target/debug/move mutate --help
+```
+or
+```bash
+./target/debug/aptos move mutate --help
+```
 
 There are also good tests in the Move Prover repository that can be used to test the tool. To run them just use:
 ```
-./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/arithm.move
-./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/bitwise_operators.move
-./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/nonlinear_arithm.move
-./target/debug/move mutate sources third_party/move/move-prover/tests/sources/functional/shift.move
+./target/debug/move mutate -m third_party/move/move-prover/tests/sources/functional/arithm.move
+./target/debug/move mutate -m third_party/move/move-prover/tests/sources/functional/bitwise_operators.move
+./target/debug/move mutate -m third_party/move/move-prover/tests/sources/functional/nonlinear_arithm.move
+./target/debug/move mutate -m third_party/move/move-prover/tests/sources/functional/shift.move
 ```
 
 To generate mutants for all files within a test project run (there are `Sum.move`, `Operators.move`, `Negation.move` and `StillSimple.move`):
 ```bash
-./target/debug/move mutate sources third_party/move/tools/move-mutator/tests/move-assets/simple/
+./target/debug/move mutate -m third_party/move/tools/move-mutator/tests/move-assets/simple/
 ```
 or appropriately for `aptos`:
 ```bash
-./target/debug/aptos move mutate --move-sources third_party/move/tools/move-mutator/tests/move-assets/simple/
+./target/debug/aptos move mutate -m third_party/move/tools/move-mutator/tests/move-assets/simple/
 ```
 
 Running the above command (`aptos` one) will generate mutants for all files within the `simple` test project and should generate following output:

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -1,87 +1,38 @@
-use clap::{Arg, Command};
+use clap::*;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
+
 /// Command line options for mutator
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Parser, Default, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Options {
     /// The paths to the Move sources.
-    pub move_sources: Vec<String>,
+    #[clap(long, short, value_parser)]
+    pub move_sources: Vec<PathBuf>,
     /// The paths to the Move sources to include.
+    #[clap(long, short, value_parser)]
     pub include_only_files: Option<Vec<PathBuf>>,
     /// The paths to the Move sources to exclude.
+    #[clap(long, short, value_parser)]
     pub exclude_files: Option<Vec<PathBuf>>,
     /// The path where to put the output files.
-    pub output_dir: Option<PathBuf>,
+    #[clap(long, short, value_parser, default_value = DEFAULT_OUTPUT_DIR)]
+    pub out_mutant_dir: PathBuf,
     /// Indicates if mutants should be verified and made sure mutants can compile.
+    #[clap(long)]
     pub verify_mutants: Option<bool>,
     /// Indicates if the output files should be overwritten.
+    #[clap(long, short)]
     pub no_overwrite: Option<bool>,
     /// Name of the filter to use for down sampling.
+    #[clap(long)]
     pub downsample_filter: Option<String>,
     /// Optional configuration file. If provided, it will override the default configuration.
+    #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
     /// Indicates if the output should be verbose.
-    pub verbose: Option<bool>,
-}
-
-impl Options {
-    /// Creates Options struct from command line arguments.
-    pub fn create_from_args(args: &[String]) -> anyhow::Result<Options> {
-        //TODO: this code need to be updated to use clap parser directly
-        let cli = Command::new("mutate")
-            .version("0.1.0")
-            .about("The Move Mutator")
-            .author("Eiger Team")
-            .arg(
-                Arg::new("sources")
-                    .num_args(1..)
-                    .value_name("PATH_TO_SOURCE_FILE")
-                    .help("the source files to mutate"),
-            )
-            .after_help("See `move-mutator/doc` and `README.md` for documentation.");
-
-        // Parse the arguments. This will abort the program on parsing errors and print help.
-        // It will also accept options like --help.
-        let matches = cli.get_matches_from(args);
-
-        // Initialize options.
-        let get_vec = |s: &str| -> Vec<String> {
-            match matches.get_many::<String>(s) {
-                Some(vs) => vs.map(|v| v.to_string()).collect(),
-                _ => vec![],
-            }
-        };
-
-        let mut options = Options::default();
-
-        if matches
-            .get_many::<String>("sources")
-            .unwrap_or_default()
-            .len()
-            > 0
-        {
-            options.move_sources = get_vec("sources");
-        }
-
-        Ok(options)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_create_from_args() {
-        let args = vec![
-            String::from("mutate"),
-            String::from("src/main.rs"),
-            String::from("src/lib.rs"),
-        ];
-
-        let options = Options::create_from_args(&args).unwrap();
-        assert_eq!(options.move_sources, vec!["src/main.rs", "src/lib.rs"]);
-    }
+    #[clap(long, short, default_value = "false")]
+    pub verbose: bool,
 }

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -35,7 +35,7 @@ pub fn generate_ast(
     config: BuildConfig,
     package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
-    let source_files = mutator_config.project.move_sources.clone();
+    let source_files = mutator_config.project.move_sources.iter().map(|p| p.to_str().unwrap_or("")).collect::<Vec<_>>();
 
     let named_addr_map = config
         .additional_named_addresses

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -110,7 +110,7 @@ mod tests {
         "#;
         fs::write("test.toml", toml_content).unwrap();
         let config = Configuration::from_toml_file(Path::new("test.toml")).unwrap();
-        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
         assert_eq!(
             config.mutation.unwrap().operators,
             vec!["operator1", "operator2"]
@@ -144,7 +144,7 @@ mod tests {
                     "move_sources": ["/path/to/move/source"],
                     "include_only_files": ["/path/to/include/file"],
                     "exclude_files": ["/path/to/exclude/file"],
-                    "output_dir": "/path/to/output",
+                    "out_mutant_dir": "/path/to/output",
                     "verify_mutants": true,
                     "no_overwrite": false,
                     "downsample_filter": "filter",
@@ -171,7 +171,7 @@ mod tests {
         "#;
         fs::write("test.json", json_content).unwrap();
         let config = Configuration::from_json_file(Path::new("test.json")).unwrap();
-        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
         assert_eq!(
             config.project.include_only_files.unwrap(),
             vec![Path::new("/path/to/include/file")]
@@ -181,7 +181,7 @@ mod tests {
             vec![Path::new("/path/to/exclude/file")]
         );
         assert_eq!(
-            config.project.output_dir.unwrap(),
+            config.project.out_mutant_dir,
             Path::new("/path/to/output")
         );
         assert_eq!(config.project.verify_mutants.unwrap(), true);
@@ -247,7 +247,7 @@ mod tests {
         "#;
         fs::write("test.json", json_content).unwrap();
         let config = Configuration::from_file(Path::new("test.json")).unwrap();
-        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
         fs::remove_file("test.json").unwrap();
     }
 
@@ -259,7 +259,7 @@ mod tests {
         "#;
         fs::write("test.toml", toml_content).unwrap();
         let config = Configuration::from_file(Path::new("test.toml")).unwrap();
-        assert_eq!(config.project.move_sources, vec!["/path/to/move/source"]);
+        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
         fs::remove_file("test.toml").unwrap();
     }
 


### PR DESCRIPTION
CLI integration with `aptos` and `move` command.

This commit unifies CLI options for the above commands and allows to set everything (what is supported) from the command line.
