### PR TITLE
[move-mutator] mutant verification

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -18,12 +18,10 @@ clap = { version = "4.3", features = ["derive"] }
 diffy = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "3.8"
 toml = "0.5"
 
 move-command-line-common = { path = "../../move-command-line-common" }
 move-compiler = { path = "../../move-compiler" }
 move-ir-types = { path = "../../move-ir/types" }
 move-package = { path = "../move-package" }
-
-[dev-dependencies]
-tempfile = "3.8"

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -21,8 +21,8 @@ pub struct Options {
     #[clap(long, short, value_parser, default_value = DEFAULT_OUTPUT_DIR)]
     pub out_mutant_dir: PathBuf,
     /// Indicates if mutants should be verified and made sure mutants can compile.
-    #[clap(long)]
-    pub verify_mutants: Option<bool>,
+    #[clap(long, default_value = "true")]
+    pub verify_mutants: bool,
     /// Indicates if the output files should be overwritten.
     #[clap(long, short)]
     pub no_overwrite: Option<bool>,

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -1,7 +1,9 @@
 use move_command_line_common::address::NumericalAddress;
 use move_command_line_common::parser::NumberFormat;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
 
 use crate::configuration::Configuration;
 use move_compiler::diagnostics::FilesSourceText;
@@ -32,13 +34,19 @@ use move_package::BuildConfig;
 /// * `Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error>` - tuple of FilesSourceText and Program if successful, or an error if any error occurs.
 pub fn generate_ast(
     mutator_config: &Configuration,
-    config: BuildConfig,
+    config: &BuildConfig,
     package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
-    let source_files = mutator_config.project.move_sources.iter().map(|p| p.to_str().unwrap_or("")).collect::<Vec<_>>();
+    let source_files = mutator_config
+        .project
+        .move_sources
+        .iter()
+        .map(|p| p.to_str().unwrap_or(""))
+        .collect::<Vec<_>>();
 
     let named_addr_map = config
         .additional_named_addresses
+        .clone()
         .into_iter()
         .map(|(name, addr)| {
             (
@@ -70,4 +78,113 @@ pub fn generate_ast(
     let (_, ast) = stepped.into_ast();
 
     Ok((files, ast))
+}
+
+/// Verify the mutant.
+/// This function compiles the mutated source and checks if the compilation is successful.
+/// If the compilation is successful, the mutant is valid.
+///
+/// # Arguments
+///
+/// * `mutator_config` - the configuration for the mutator.
+/// * `config` - the build configuration.
+/// * `mutated_source` - the mutated source code as a string.
+/// * `original_file` - the path to the original file.
+///
+/// # Returns
+///
+/// * `Result<(), anyhow::Error>` - Ok if the mutant is valid, or an error if any error occurs.
+pub fn verify_mutant(
+    mutator_config: &Configuration,
+    config: &BuildConfig,
+    mutated_source: &str,
+    original_file: &Path,
+) -> Result<(), anyhow::Error> {
+    // Find the root for the package
+    let rooted_path = SourcePackageLayout::try_find_root(&original_file.canonicalize()?)?;
+
+    // Get the relative path to the original file
+    let relative_path = original_file.canonicalize().unwrap();
+    let relative_path = relative_path.strip_prefix(&rooted_path)?;
+
+    let tempdir = tempfile::tempdir()?;
+
+    // Copy the whole package to the tempdir
+    // We need to copy the whole package because the Move compiler needs to find the Move.toml file and all the dependencies
+    // as we don't know which files are needed for the compilation
+    copy_dir_all(&rooted_path, &tempdir.path())?;
+
+    // Write the mutated source to the tempdir in place of the original file
+    std::fs::write(tempdir.path().join(relative_path), mutated_source)?;
+
+    let mut output: Box<dyn Write> = if mutator_config.project.verbose {
+        Box::new(std::io::stdout())
+    } else {
+        Box::new(std::io::sink())
+    };
+
+    // Compile the package
+    config
+        .clone()
+        .compile_package(&tempdir.path(), &mut output)?;
+
+    Ok(())
+}
+
+/// Copies all files and directories from the source directory to the destination directory.
+///
+/// # Arguments
+///
+/// * `src` - the source directory.
+/// * `dst` - the destination directory.
+///
+/// # Returns
+///
+/// * `io::Result<()>` - Ok if the copy is successful, or an error if any error occurs.
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    if !dst.as_ref().exists() {
+        fs::create_dir_all(dst.as_ref())?;
+    }
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn copy_dir_all_copies_all_files_and_directories() {
+        let temp_dir = tempdir().unwrap();
+        let src_dir = temp_dir.path().join("src");
+        let dst_dir = temp_dir.path().join("dst");
+
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::write(src_dir.join("file.txt"), "Hello, world!").unwrap();
+
+        let result = copy_dir_all(&src_dir, &dst_dir);
+        assert!(result.is_ok());
+        assert!(dst_dir.join("file.txt").exists());
+    }
+
+    #[test]
+    fn copy_dir_all_errors_if_source_does_not_exist() {
+        let temp_dir = tempdir().unwrap();
+        let src_dir = temp_dir.path().join("non_existent_src");
+        let dst_dir = temp_dir.path().join("dst");
+
+        let result = copy_dir_all(&src_dir, &dst_dir);
+        assert!(result.is_err());
+    }
 }

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -110,7 +110,10 @@ mod tests {
         "#;
         fs::write("test.toml", toml_content).unwrap();
         let config = Configuration::from_toml_file(Path::new("test.toml")).unwrap();
-        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
+        assert_eq!(
+            config.project.move_sources,
+            vec![Path::new("/path/to/move/source")]
+        );
         assert_eq!(
             config.mutation.unwrap().operators,
             vec!["operator1", "operator2"]
@@ -171,7 +174,10 @@ mod tests {
         "#;
         fs::write("test.json", json_content).unwrap();
         let config = Configuration::from_json_file(Path::new("test.json")).unwrap();
-        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
+        assert_eq!(
+            config.project.move_sources,
+            vec![Path::new("/path/to/move/source")]
+        );
         assert_eq!(
             config.project.include_only_files.unwrap(),
             vec![Path::new("/path/to/include/file")]
@@ -180,11 +186,8 @@ mod tests {
             config.project.exclude_files.unwrap(),
             vec![Path::new("/path/to/exclude/file")]
         );
-        assert_eq!(
-            config.project.out_mutant_dir,
-            Path::new("/path/to/output")
-        );
-        assert_eq!(config.project.verify_mutants.unwrap(), true);
+        assert_eq!(config.project.out_mutant_dir, Path::new("/path/to/output"));
+        assert_eq!(config.project.verify_mutants, true);
         assert_eq!(config.project.no_overwrite.unwrap(), false);
         assert_eq!(config.project.downsample_filter.unwrap(), "filter");
         assert_eq!(
@@ -247,7 +250,10 @@ mod tests {
         "#;
         fs::write("test.json", json_content).unwrap();
         let config = Configuration::from_file(Path::new("test.json")).unwrap();
-        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
+        assert_eq!(
+            config.project.move_sources,
+            vec![Path::new("/path/to/move/source")]
+        );
         fs::remove_file("test.json").unwrap();
     }
 
@@ -259,7 +265,10 @@ mod tests {
         "#;
         fs::write("test.toml", toml_content).unwrap();
         let config = Configuration::from_file(Path::new("test.toml")).unwrap();
-        assert_eq!(config.project.move_sources, vec![Path::new("/path/to/move/source")]);
+        assert_eq!(
+            config.project.move_sources,
+            vec![Path::new("/path/to/move/source")]
+        );
         fs::remove_file("test.toml").unwrap();
     }
 

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -8,7 +8,7 @@ mod mutant;
 mod operator;
 mod report;
 
-use crate::compiler::generate_ast;
+use crate::compiler::{generate_ast, verify_mutant};
 use std::path::Path;
 
 use crate::cli::DEFAULT_OUTPUT_DIR;
@@ -34,7 +34,7 @@ pub fn run_move_mutator(
         None => configuration::Configuration::new(options, Some(package_path.clone())),
     };
 
-    let (files, ast) = generate_ast(&mutator_configuration, config, package_path)?;
+    let (files, ast) = generate_ast(&mutator_configuration, &config, package_path)?;
 
     let mutants = mutate::mutate(ast)?;
 
@@ -65,6 +65,18 @@ pub fn run_move_mutator(
         for mutant in mutants.iter().filter(|m| m.get_file_hash() == hash) {
             let mutated_sources = mutant.apply(&source);
             for mutated in mutated_sources {
+                if mutator_configuration.project.verify_mutants {
+                    let res = verify_mutant(
+                        &mutator_configuration,
+                        &config,
+                        &mutated.mutated_source,
+                        path,
+                    );
+                    if res.is_err() {
+                        continue;
+                    }
+                }
+
                 let mutant_path = setup_mutant_path(&output_dir, file_name, i);
                 std::fs::write(&mutant_path, &mutated.mutated_source)?;
 
@@ -82,6 +94,7 @@ pub fn run_move_mutator(
                     &mutated.mutated_source,
                     &source,
                 );
+
                 entry.add_modification(mutated.mutation);
                 report.add_entry(entry);
                 i += 1;

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -72,6 +72,7 @@ pub fn run_move_mutator(
                         &mutated.mutated_source,
                         path,
                     );
+                    // In case the mutant is not a valid Move file, skip the mutant (do not save it)
                     if res.is_err() {
                         continue;
                     }


### PR DESCRIPTION
This PR introduces mutant verification.

Verification is done by copying the whole package to the temp directory (which should be cheap as temp directory should reside in some tmpfs so in RAM generally) and then, original file is replaced by the mutated source.

Compiler is run over the whole package and result is checked. If compilation fails mutant is not created in the output directory and is not added to the report.