### PR TITLE
[move-spec-test] initial `spec-test` skeleton with Move CLI integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,6 +234,7 @@ members = [
     "third_party/move/tools/move-mutator",
     "third_party/move/tools/move-package",
     "third_party/move/tools/move-resource-viewer",
+    "third_party/move/tools/move-spec-test",
     "third_party/move/tools/move-unit-test",
     "types",
     "vm-validator",
@@ -711,6 +712,7 @@ move-package = { path = "third_party/move/tools/move-package" }
 move-prover = { path = "third_party/move/move-prover" }
 move-prover-boogie-backend = { path = "third_party/move/move-prover/boogie-backend" }
 move-prover-bytecode-pipeline = { path = "third_party/move/move-prover/bytecode-pipeline" }
+move-spec-test = { path = "third_party/move/tools/move-spec-test" }
 move-stackless-bytecode = { path = "third_party/move/move-model/bytecode" }
 move-stackless-bytecode-test-utils = { path = "third_party/move/move-model/bytecode-test-utils" }
 aptos-move-stdlib = { path = "aptos-move/framework/move-stdlib" }

--- a/third_party/move/tools/move-cli/Cargo.toml
+++ b/third_party/move/tools/move-cli/Cargo.toml
@@ -46,6 +46,7 @@ move-mutator = { path = "../move-mutator" }
 move-package = { path = "../move-package" }
 move-prover = { path = "../../move-prover" }
 move-resource-viewer = { path = "../move-resource-viewer" }
+move-spec-test = { path = "../move-spec-test" }
 move-stdlib = { path = "../../move-stdlib" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-table-extension = { path = "../../extensions/move-table-extension", optional = true }

--- a/third_party/move/tools/move-cli/src/base/mod.rs
+++ b/third_party/move/tools/move-cli/src/base/mod.rs
@@ -11,6 +11,7 @@ pub mod movey_upload;
 pub mod mutate;
 pub mod new;
 pub mod prove;
+pub mod spec_test;
 pub mod test;
 pub mod test_validation;
 

--- a/third_party/move/tools/move-cli/src/base/spec_test.rs
+++ b/third_party/move/tools/move-cli/src/base/spec_test.rs
@@ -1,0 +1,28 @@
+use clap::*;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+/// Test the Move specification using the Move Mutator and Move Prover
+#[derive(Parser)]
+#[clap(name = "spec-test")]
+pub struct SpecTest {
+    /// Any options passed to the move-spec-test
+    #[clap(flatten)]
+    pub options: Option<move_spec_test::cli::Options>,
+}
+
+impl SpecTest {
+    /// Executes the spec-test command which produces mutants from the Move files or package using
+    /// the provided configuration. Then it passes the mutants to the Move prover to check if the
+    /// mutants are killed by the prover.
+    /// If no path is provided, the current directory is used.
+    pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
+        let path = path.unwrap_or_else(|| PathBuf::from("."));
+
+        let Self { options } = self;
+
+        let options = options.unwrap_or_default();
+
+        move_spec_test::run_spec_test(options, config, path)
+    }
+}

--- a/third_party/move/tools/move-cli/src/lib.rs
+++ b/third_party/move/tools/move-cli/src/lib.rs
@@ -4,7 +4,7 @@
 
 use base::{
     build::Build, coverage::Coverage, disassemble::Disassemble, docgen::Docgen, errmap::Errmap,
-    movey_login::MoveyLogin, movey_upload::MoveyUpload, mutate::Mutate, new::New, prove::Prove, test::Test,
+    movey_login::MoveyLogin, movey_upload::MoveyUpload, mutate::Mutate, new::New, prove::Prove, spec_test::SpecTest, test::Test,
 };
 use move_package::BuildConfig;
 
@@ -71,6 +71,7 @@ pub enum Command {
     Mutate(Mutate),
     New(New),
     Prove(Prove),
+    SpecTest(SpecTest),
     Test(Test),
     /// Execute a sandbox command.
     #[clap(name = "sandbox")]
@@ -106,6 +107,7 @@ pub fn run_cli(
         Command::Mutate(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::New(c) => c.execute_with_defaults(move_args.package_path),
         Command::Prove(c) => c.execute(move_args.package_path, move_args.build_config),
+        Command::SpecTest(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Test(c) => c.execute(
             move_args.package_path,
             move_args.build_config,

--- a/third_party/move/tools/move-spec-test/Cargo.toml
+++ b/third_party/move/tools/move-spec-test/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "move-spec-test"
+version = "0.1.0"
+authors = ["Eiger <hello@eiger.co>"]
+
+description = "Move specification testing tool"
+
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.3", features = ["derive"] }
+log = "0.4"
+pretty_env_logger = "0.5"
+serde = { version = "1.0", features = ["derive"] }
+
+move-command-line-common = { path = "../../move-command-line-common" }
+move-mutator = { path = "../move-mutator" }
+move-package = { path = "../move-package" }
+move-prover = { path = "../../move-prover" }

--- a/third_party/move/tools/move-spec-test/README.md
+++ b/third_party/move/tools/move-spec-test/README.md
@@ -1,0 +1,1 @@
+# Move Specification Test tool

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -1,0 +1,27 @@
+use clap::*;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Command line options for specification test tool
+#[derive(Parser, Default, Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Options {
+    /// The paths to the Move sources.
+    #[clap(long, short, value_parser)]
+    pub move_sources: Vec<PathBuf>,
+    /// The paths to the Move sources to include.
+    #[clap(long, short, value_parser)]
+    pub include_only_files: Option<Vec<PathBuf>>,
+    /// The paths to the Move sources to exclude.
+    #[clap(long, short, value_parser)]
+    pub exclude_files: Option<Vec<PathBuf>>,
+    /// Optional configuration file for mutator tool.
+    #[clap(long, value_parser)]
+    pub mutator_conf: Option<PathBuf>,
+    /// Optional configuration file for prover tool.
+    #[clap(long, value_parser)]
+    pub prover_conf: Option<PathBuf>,
+    /// Extra arguments to pass to the prover.
+    #[clap(long, value_parser)]
+    pub extra_prover_args: Option<Vec<String>>,
+}

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -2,7 +2,7 @@ use clap::*;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-/// Command line options for specification test tool
+/// Command line options for specification test tool.
 #[derive(Parser, Default, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Options {

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -7,7 +7,8 @@ extern crate log;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
-/// This function runs the specification testing.
+/// This function runs the specification testing, which is a combination of the
+/// mutator tool and the prover tool
 /// It takes the CLI options and constructs appropriate options for the
 /// Move Mutator tool and Move Prover tool. Then it mutates the code storing
 /// results in a temporary directory. Then it runs the prover on the mutated

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -1,0 +1,37 @@
+pub mod cli;
+
+extern crate pretty_env_logger;
+#[macro_use]
+extern crate log;
+
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+/// This function runs the specification testing.
+/// It takes the CLI options and constructs appropriate options for the
+/// Move Mutator tool and Move Prover tool. Then it mutates the code storing
+/// results in a temporary directory. Then it runs the prover on the mutated
+/// code and remember the results, using them to generate the report at the end.
+///
+/// # Arguments
+///
+/// * `options` - A `cli::Options` representing the options for the spec test.
+/// * `config` - A `BuildConfig` representing the build configuration.
+/// * `package_path` - A `PathBuf` representing the path to the package.
+///
+/// # Returns
+///
+/// * `anyhow::Result<()>` - The result of the spec test.
+pub fn run_spec_test(
+    _options: cli::Options,
+    _config: BuildConfig,
+    _package_path: PathBuf,
+) -> anyhow::Result<()> {
+    pretty_env_logger::init();
+
+    info!("Running spec test");
+
+    // TODO: implement
+
+    Ok(())
+}


### PR DESCRIPTION
Initial `spec-test` package skeleton. Integration with the Aptos buildsystem and Move command line interface.
