### PR TITLE
[move-spec-test] `aptos` command integration

### DIFF
--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -75,6 +75,7 @@ move-disassembler = { workspace = true }
 move-ir-types = { workspace = true }
 move-mutator = { workspace = true }
 move-package = { workspace = true }
+move-spec-test = { workspace = true }
 move-symbol-pool = { workspace = true }
 move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -113,6 +113,8 @@ pub enum CliError {
     CoverageError(String),
     #[error("Move mutator failed: {0}")]
     MoveMutatorError(String),
+    #[error("Move spec-test failed: {0}")]
+    MoveSpecTestError(String),
 }
 
 impl CliError {
@@ -134,6 +136,7 @@ impl CliError {
             CliError::UnexpectedError(_) => "UnexpectedError",
             CliError::SimulationError(_) => "SimulationError",
             CliError::CoverageError(_) => "CoverageError",
+            CliError::MoveSpecTestError(_) => "MoveSpecTestError",
         }
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -92,6 +92,7 @@ pub enum MoveTool {
     RunScript(RunScript),
     #[clap(subcommand, hide = true)]
     Show(show::ShowTool),
+    SpecTest(SpecTestPackage),
     Test(TestPackage),
     VerifyPackage(VerifyPackage),
     View(ViewFunction),
@@ -119,6 +120,7 @@ impl MoveTool {
             MoveTool::Run(tool) => tool.execute_serialized().await,
             MoveTool::RunScript(tool) => tool.execute_serialized().await,
             MoveTool::Show(tool) => tool.execute_serialized().await,
+            MoveTool::SpecTest(tool) => tool.execute_serialized().await,
             MoveTool::Test(tool) => tool.execute_serialized().await,
             MoveTool::VerifyPackage(tool) => tool.execute_serialized().await,
             MoveTool::View(tool) => tool.execute_serialized().await,
@@ -555,16 +557,69 @@ impl CliCommand<&'static str> for MutatePackage {
 
         let path = self.move_options.get_package_path()?;
 
-        let result = move_mutator::run_move_mutator(
-            mutator_options.unwrap_or_default(),
-            config,
-            path,
-        )
-        .map_err(|err| CliError::UnexpectedError(err.to_string()));
+        let result =
+            move_mutator::run_move_mutator(mutator_options.unwrap_or_default(), config, path)
+                .map_err(|err| CliError::UnexpectedError(err.to_string()));
 
         match result {
             Ok(_) => Ok("Success"),
             Err(e) => Err(CliError::MoveMutatorError(format!("{:#}", e))),
+        }
+    }
+}
+
+/// Test specification of a Move package.
+#[derive(Parser)]
+pub struct SpecTestPackage {
+    /// Options for parsing and compiling a move package dir
+    #[clap(flatten)]
+    move_options: MovePackageDir,
+    /// Options specific for the spec-test tool
+    #[clap(flatten)]
+    spec_test_options: Option<move_spec_test::cli::Options>,
+}
+
+#[async_trait]
+impl CliCommand<&'static str> for SpecTestPackage {
+    /// Returns the name of the command used in the CLI.
+    fn command_name(&self) -> &'static str {
+        "SpecTestPackage"
+    }
+
+    /// Executes the spec-test command. Internally, it generates mutants with the provided parameters and passes them to the
+    /// Prover.
+    async fn execute(self) -> CliTypedResult<&'static str> {
+        let crate::move_tool::SpecTestPackage {
+            move_options: _,
+            spec_test_options,
+        } = self;
+
+        let known_attributes = extended_checks::get_all_attribute_names();
+        let config = BuildConfig {
+            dev_mode: self.move_options.dev,
+            additional_named_addresses: self.move_options.named_addresses(),
+            test_mode: false,
+            full_model_generation: self.move_options.check_test_code,
+            install_dir: self.move_options.output_dir.clone(),
+            skip_fetch_latest_git_deps: self.move_options.skip_fetch_latest_git_deps,
+            compiler_config: CompilerConfig {
+                known_attributes: known_attributes.clone(),
+                skip_attribute_checks: self.move_options.skip_attribute_checks,
+                compiler_version: self.move_options.compiler_version,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let path = self.move_options.get_package_path()?;
+
+        let result =
+            move_spec_test::run_spec_test(spec_test_options.unwrap_or_default(), config, path)
+                .map_err(|err| CliError::UnexpectedError(err.to_string()));
+
+        match result {
+            Ok(_) => Ok("Success"),
+            Err(e) => Err(CliError::MoveSpecTestError(format!("{:#}", e))),
         }
     }
 }


### PR DESCRIPTION
Integrate `spec-test` as `aptos move` subcommand.