### PR TITLE
[move-mutator] use package path correctly and create proper Options

### DIFF
--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 pub const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
 
 /// Command line options for mutator
-#[derive(Parser, Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Parser, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Options {
     /// The paths to the Move sources.
@@ -32,4 +32,22 @@ pub struct Options {
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
+}
+
+impl Default for Options {
+    // We need to implement default just because we need to specify the default value for out_mutant_dir.
+    // Otherwise, out_mutant_dir would be empty. This is special case, when user won't specify any Options
+    // (so the default value would be used), but define package_path (which is passed using other mechanism).
+    fn default() -> Self {
+        Self {
+            move_sources: vec![],
+            include_only_files: None,
+            exclude_files: None,
+            out_mutant_dir: PathBuf::from(DEFAULT_OUTPUT_DIR),
+            verify_mutants: true,
+            no_overwrite: None,
+            downsample_filter: None,
+            configuration_file: None,
+        }
+    }
 }

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -34,14 +34,21 @@ use move_package::BuildConfig;
 pub fn generate_ast(
     mutator_config: &Configuration,
     config: &BuildConfig,
-    _package_path: PathBuf,
+    package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
-    let source_files = mutator_config
+    let mut source_files = mutator_config
         .project
         .move_sources
         .iter()
         .map(|p| p.to_str().unwrap_or(""))
         .collect::<Vec<_>>();
+
+    // If -m option is specified we should only `move_sources`. However, if `move_sources` is empty
+    // we should add a package path. This path should be always set by the calling function.
+    // In case of any error we should use current directory as package root.
+    if source_files.is_empty() {
+        source_files.push(package_path.to_str().unwrap_or("."));
+    }
 
     debug!("Source files and folders: {:?}", source_files);
 

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -154,8 +154,8 @@ fn setup_mutant_path(output_dir: &Path, filename: &str, index: u64) -> PathBuf {
 ///
 /// * `anyhow::Result<PathBuf>` - Returns the path to the output directory if successful, or an error if any error occurs.
 fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow::Result<PathBuf> {
-    trace!("Setting up output directory");
     let output_dir = mutator_configuration.project.out_mutant_dir.clone();
+    trace!("Trying to set up output directory to: {:?}", output_dir);
 
     // Check if output directory exists and if it should be overwritten
     if output_dir.exists() && mutator_configuration.project.no_overwrite.unwrap_or(false) {


### PR DESCRIPTION
### Description

We need to implement defaults manually for the cli::Options just because we need to specify the default value for out_mutant_dir. Otherwise, out_mutant_dir would be empty. This is special case, when user won't specify any Options (so the default value would be used), but define package_path (which is passed using other mechanism).

Package path is always set by the mutator caller. It's set to either -p option (by the user) or to ".". We prefer to use move_sources (-m option) as user may want to pass single Move files, which may be placed somewhere outside any valid package. And mutator tool should handle them smoothly (those files just can't be verified as we can't compile something that's not a package).
