### PR TITLE
feat: call prover and record results

### DIFF
--- a/third_party/move/tools/move-cli/src/base/spec_test.rs
+++ b/third_party/move/tools/move-cli/src/base/spec_test.rs
@@ -1,6 +1,7 @@
 use clap::*;
 use move_package::BuildConfig;
 use std::path::PathBuf;
+use crate::base::reroot_path;
 
 /// Test the Move specification using the Move Mutator and Move Prover
 #[derive(Parser)]
@@ -17,12 +18,12 @@ impl SpecTest {
     /// mutants are killed by the prover.
     /// If no path is provided, the current directory is used.
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
-        let path = path.unwrap_or_else(|| PathBuf::from("."));
+        let rerooted_path = reroot_path(path)?;
 
         let Self { options } = self;
 
         let options = options.unwrap_or_default();
 
-        move_spec_test::run_spec_test(options, config, path)
+        move_spec_test::run_spec_test(options, config, rerooted_path)
     }
 }

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -18,8 +18,8 @@ pub struct Options {
     #[clap(long, short, value_parser)]
     pub exclude_files: Option<Vec<PathBuf>>,
     /// The path where to put the output files.
-    #[clap(long, short, value_parser, default_value = DEFAULT_OUTPUT_DIR)]
-    pub out_mutant_dir: PathBuf,
+    #[clap(long, short, value_parser)]
+    pub out_mutant_dir: Option<PathBuf>,
     /// Indicates if mutants should be verified and made sure mutants can compile.
     #[clap(long, default_value = "false")]
     pub verify_mutants: bool,
@@ -43,7 +43,7 @@ impl Default for Options {
             move_sources: vec![],
             include_only_files: None,
             exclude_files: None,
-            out_mutant_dir: PathBuf::from(DEFAULT_OUTPUT_DIR),
+            out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: true,
             no_overwrite: None,
             downsample_filter: None,

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+use crate::cli;
 use crate::configuration::Configuration;
 use move_compiler::diagnostics::FilesSourceText;
 use move_compiler::{
@@ -67,6 +68,8 @@ pub fn generate_ast(
     let interface_files_dir = mutator_config
         .project
         .out_mutant_dir
+        .clone()
+        .unwrap_or(PathBuf::from(cli::DEFAULT_OUTPUT_DIR))
         .join("generated_interface_files/mutator_build");
     let flags = Flags::empty();
 

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -169,7 +169,7 @@ pub fn verify_mutant(
 /// # Returns
 ///
 /// * `io::Result<()>` - Ok if the copy is successful, or an error if any error occurs.
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     if !dst.as_ref().exists() {
         fs::create_dir_all(dst.as_ref())?;
     }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -3,7 +3,7 @@ extern crate pretty_env_logger;
 extern crate log;
 
 pub mod cli;
-mod compiler;
+pub mod compiler;
 
 mod mutate;
 
@@ -11,7 +11,7 @@ mod configuration;
 mod mutant;
 mod operator;
 mod output;
-mod report;
+pub mod report;
 
 use crate::compiler::{generate_ast, verify_mutant};
 use std::fs;

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -7,7 +7,7 @@ pub mod compiler;
 
 mod mutate;
 
-mod configuration;
+pub mod configuration;
 mod mutant;
 mod operator;
 mod output;

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::io::Write;
+use std::io::{Error, ErrorKind, Result, Write};
 use std::path::{Path, PathBuf};
 
 /// The `Report` struct represents a report of mutations.
@@ -26,26 +26,25 @@ impl Report {
     }
 
     /// Saves the `Report` as a JSON file.
-    pub fn save_to_json_file(&self, path: &Path) -> std::io::Result<()> {
+    pub fn save_to_json_file(&self, path: &Path) -> Result<()> {
         let file = std::fs::File::create(path)?;
 
         info!("Saving report to {}", path.display());
 
-        serde_json::to_writer_pretty(file, &self)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        serde_json::to_writer_pretty(file, &self).map_err(|e| Error::new(ErrorKind::Other, e))
     }
 
     /// Loads the `Report` from a JSON file.
-    pub fn load_from_json_file(path: &Path) -> std::io::Result<Self> {
+    pub fn load_from_json_file(path: &Path) -> Result<Self> {
         info!("Reading report from {}", path.display());
 
         let file = std::fs::File::open(path)?;
 
-        serde_json::from_reader(file).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        serde_json::from_reader(file).map_err(|e| Error::new(ErrorKind::Other, e))
     }
 
     /// Saves the `Report` as a text file.
-    pub fn save_to_text_file(&self, path: &Path) -> std::io::Result<()> {
+    pub fn save_to_text_file(&self, path: &Path) -> Result<()> {
         let mut file = std::fs::File::create(path)?;
 
         info!("Saving report to {}", path.display());
@@ -175,13 +174,13 @@ impl MutationReport {
         self.mutations.push(modification);
     }
 
-    /// Return the mutant path
-    pub fn get_mutant_path(&self) -> &PathBuf {
+    /// Return the mutant path.
+    pub fn mutant_path(&self) -> &PathBuf {
         &self.mutant_path
     }
 
-    /// Return the original file path
-    pub fn get_original_file_path(&self) -> &PathBuf {
+    /// Return the original file path.
+    pub fn original_file_path(&self) -> &PathBuf {
         &self.original_file
     }
 }

--- a/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "poor_spec"
+version = "0.0.0"
+
+[addresses]
+TestAccount = "0xCAFE"

--- a/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
@@ -1,0 +1,12 @@
+module TestAccount::Sum {
+    fun sum(x: u128, y: u128): u128 {
+        let sum_r = x + y;
+
+        spec {
+                // Senseless specification
+                assert sum_r >= 0;
+        };
+
+        sum_r
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
@@ -3,7 +3,7 @@ module TestAccount::Sum {
         let sum_r = x + y;
 
         spec {
-                // Senseless specification
+                // Senseless specification - mutator will change + operator to -*/ but spec won't notice it.
                 assert sum_r >= 0;
         };
 

--- a/third_party/move/tools/move-spec-test/Cargo.toml
+++ b/third_party/move/tools/move-spec-test/Cargo.toml
@@ -18,6 +18,8 @@ clap = { version = "4.3", features = ["derive"] }
 log = "0.4"
 pretty_env_logger = "0.5"
 serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.9"
+termcolor = "1.1"
 
 move-command-line-common = { path = "../../move-command-line-common" }
 move-mutator = { path = "../move-mutator" }

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -25,3 +25,34 @@ pub struct Options {
     #[clap(long, value_parser)]
     pub extra_prover_args: Option<Vec<String>>,
 }
+
+/// This function creates a mutator CLI options from the given spec-test options.
+/// It clones the move_sources, include_only_files, exclude_files, and configuration_file from the given options.
+/// The rest of the options are set to default.
+pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
+    move_mutator::cli::Options {
+        move_sources: options.move_sources.clone(),
+        include_only_files: options.include_only_files.clone(),
+        exclude_files: options.exclude_files.clone(),
+        configuration_file: options.mutator_conf.clone(),
+        ..Default::default()
+    }
+}
+
+/// This function generates a prover CLI options from the given spec-test options.
+/// It first checks if a prover configuration file is provided in the options.
+/// If it is, it creates the prover options from the configuration file.
+/// If it is not, it checks if extra prover arguments are provided in the options.
+/// If they are, it creates the prover options from the arguments.
+/// Otherwise, it creates the default prover options.
+pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover::cli::Options> {
+    let prover_conf = if let Some(conf) = &options.prover_conf {
+        move_prover::cli::Options::create_from_toml_file(conf.to_str().unwrap_or(""))?
+    } else if let Some(args) = &options.extra_prover_args {
+        move_prover::cli::Options::create_from_args(args)?
+    } else {
+        move_prover::cli::Options::default()
+    };
+
+    Ok(prover_conf)
+}

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -27,8 +27,6 @@ pub struct Options {
 }
 
 /// This function creates a mutator CLI options from the given spec-test options.
-/// It clones the move_sources, include_only_files, exclude_files, and configuration_file from the given options.
-/// The rest of the options are set to default.
 pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
     move_mutator::cli::Options {
         move_sources: options.move_sources.clone(),
@@ -40,11 +38,6 @@ pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
 }
 
 /// This function generates a prover CLI options from the given spec-test options.
-/// It first checks if a prover configuration file is provided in the options.
-/// If it is, it creates the prover options from the configuration file.
-/// If it is not, it checks if extra prover arguments are provided in the options.
-/// If they are, it creates the prover options from the arguments.
-/// Otherwise, it creates the default prover options.
 pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover::cli::Options> {
     let prover_conf = if let Some(conf) = &options.prover_conf {
         move_prover::cli::Options::create_from_toml_file(conf.to_str().unwrap_or(""))?
@@ -55,4 +48,18 @@ pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover:
     };
 
     Ok(prover_conf)
+}
+
+/// This function checks if the mutator output path is provided in the configuration file.
+/// We don't need to check if the mutator output path is provided in the options as they were created
+/// from the spec-test options which does not allow to set it..
+pub fn check_mutator_output_path(options: &move_mutator::cli::Options) -> Option<PathBuf> {
+    if let Some(conf) = &options.configuration_file {
+        let c = move_mutator::configuration::Configuration::from_file(conf);
+        if let Ok(c) = c {
+            return c.project.out_mutant_dir;
+        }
+    };
+
+    None
 }

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -1,9 +1,12 @@
 pub mod cli;
+mod prover;
 
 extern crate pretty_env_logger;
 #[macro_use]
 extern crate log;
 
+use crate::prover::prove;
+use anyhow::anyhow;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
@@ -24,15 +27,79 @@ use std::path::PathBuf;
 ///
 /// * `anyhow::Result<()>` - The result of the spec test.
 pub fn run_spec_test(
-    _options: cli::Options,
-    _config: BuildConfig,
-    _package_path: PathBuf,
+    options: cli::Options,
+    config: BuildConfig,
+    package_path: PathBuf,
 ) -> anyhow::Result<()> {
-    pretty_env_logger::init();
+    // We need to initialize logger using try_init() as it might be already initialized in some other tool
+    // (e.g. spec-test). If we use init() instead, we will get an abort.
+    let _ = pretty_env_logger::try_init();
 
     info!("Running spec test");
 
-    // TODO: implement
+    let mut mutator_conf = cli::create_mutator_options(&options);
+    let prover_conf = cli::generate_prover_options(&options)?;
+
+    // Setup temporary directory structure
+    let outdir = tempfile::tempdir()?.into_path();
+    let outdir_mutant = outdir.join("mutants");
+    let outdir_original = outdir.join("base");
+
+    std::fs::create_dir_all(&outdir_mutant)?;
+    std::fs::create_dir_all(&outdir_original)?;
+
+    mutator_conf.out_mutant_dir = outdir_mutant.clone();
+
+    debug!("Running the move mutator tool");
+
+    move_mutator::run_move_mutator(mutator_conf, config.clone(), package_path.clone())?;
+
+    let report =
+        move_mutator::report::Report::load_from_json_file(&outdir_mutant.join("report.json"))?;
+
+    // Proving part
+    move_mutator::compiler::copy_dir_all(&package_path, &outdir_original)?;
+
+    let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
+
+    let result = prove(&config, &package_path, &prover_conf, &mut error_writer);
+
+    if let Err(e) = result {
+        let msg = format!(
+            "Original code verification failed! Prover failed with error: {}",
+            e
+        );
+        error!("{msg}");
+        return Err(anyhow!(msg));
+    }
+
+    // TODO: change this to report generation
+    let mut total_mutants = 0;
+    let mut killed_mutants = 0;
+
+    for elem in report.get_mutants() {
+        total_mutants += 1;
+
+        let result = prover::prove_mutant(
+            &config,
+            &elem.get_mutant_path(),
+            &elem.get_original_file_path(),
+            &package_path,
+            &prover_conf,
+            &outdir.join("prove"),
+            &mut error_writer,
+        );
+
+        if let Err(e) = result {
+            trace!("Mutant killed! Prover failed with error: {}", e);
+            killed_mutants += 1;
+        } else {
+            trace!("Mutant hasn't been killed!");
+        }
+    }
+
+    println!("Total mutants: {}", total_mutants);
+    println!("Killed mutants: {}", killed_mutants);
 
     Ok(())
 }

--- a/third_party/move/tools/move-spec-test/src/prover.rs
+++ b/third_party/move/tools/move-spec-test/src/prover.rs
@@ -1,0 +1,88 @@
+use anyhow::anyhow;
+use move_package::{BuildConfig, ModelConfig};
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+use termcolor::WriteColor;
+
+/// The `prove_mutant` function is responsible for setting up the output
+/// directory and calling function proving the mutant.
+///
+/// # Arguments
+///
+/// * `config` - A `BuildConfig` representing the build configuration.
+/// * `mutant_file` - `Path` the path to the mutant file.
+/// * `original_file` - `Path` the path to the original file.
+/// * `package_path` - `Path` the path to the package.
+/// * `prover_conf` - `move_prover::cli::Options` the options for the prover.
+/// * `outdir_prove` - `Path` the path to the output directory for proving.
+/// * `error_writer` - `&mut dyn std::io::Write` representing the error writer.
+///
+/// # Returns
+///
+/// * `anyhow::Result<()>` - The result of the proving process.
+pub(crate) fn prove_mutant<W: WriteColor>(
+    config: &BuildConfig,
+    mutant_file: &Path,
+    original_file: &Path,
+    package_path: &Path,
+    prover_conf: &move_prover::cli::Options,
+    outdir_prove: &Path,
+    mut error_writer: &mut W,
+) -> anyhow::Result<()> {
+    debug!("Original file: {:?}", original_file);
+    debug!("Mutant file: {:?}", mutant_file);
+
+    let _ = fs::remove_dir_all(&outdir_prove);
+    move_mutator::compiler::copy_dir_all(&package_path, &outdir_prove)?;
+
+    trace!(
+        "Copying mutant file {:?} to the package directory {:?}",
+        mutant_file,
+        outdir_prove.join(original_file)
+    );
+
+    if let Err(res) = fs::copy(mutant_file, outdir_prove.join(original_file)) {
+        let msg = format!("Can't copy mutant file to the package directory: {:?}", res);
+        warn!("{msg}");
+        return Err(anyhow!(msg));
+    }
+
+    prove(&config, &outdir_prove, &prover_conf, &mut error_writer)
+}
+
+/// The `prove` function is responsible for proving the package.
+///
+/// # Arguments
+///
+/// * `config` - A `BuildConfig` representing the build configuration.
+/// * `package_path` - A `Path` to the package.
+/// * `prover_conf` - `move_prover::cli::Options` the options for the prover.
+/// * `error_writer` - `&mut dyn std::io::Write` the error writer.
+///
+/// # Returns
+///
+/// * `anyhow::Result<()>` - The result of the proving process.
+pub(crate) fn prove<W: WriteColor>(
+    config: &BuildConfig,
+    package_path: &Path,
+    prover_conf: &move_prover::cli::Options,
+    mut error_writer: &mut W,
+) -> anyhow::Result<()> {
+    let model = config.clone().move_model_for_package(
+        package_path,
+        ModelConfig {
+            all_files_as_targets: true,
+            target_filter: None,
+        },
+    )?;
+
+    let now = Instant::now();
+
+    move_prover::run_move_prover_with_model(
+        &model,
+        &mut error_writer,
+        prover_conf.clone(),
+        Some(now),
+    )
+}

--- a/third_party/move/tools/move-spec-test/src/prover.rs
+++ b/third_party/move/tools/move-spec-test/src/prover.rs
@@ -1,55 +1,7 @@
-use anyhow::anyhow;
 use move_package::{BuildConfig, ModelConfig};
-use std::fs;
 use std::path::Path;
 use std::time::Instant;
 use termcolor::WriteColor;
-
-/// The `prove_mutant` function is responsible for setting up the output
-/// directory and calling function proving the mutant.
-///
-/// # Arguments
-///
-/// * `config` - A `BuildConfig` representing the build configuration.
-/// * `mutant_file` - `Path` the path to the mutant file.
-/// * `original_file` - `Path` the path to the original file.
-/// * `package_path` - `Path` the path to the package.
-/// * `prover_conf` - `move_prover::cli::Options` the options for the prover.
-/// * `outdir_prove` - `Path` the path to the output directory for proving.
-/// * `error_writer` - `&mut dyn std::io::Write` representing the error writer.
-///
-/// # Returns
-///
-/// * `anyhow::Result<()>` - The result of the proving process.
-pub(crate) fn prove_mutant<W: WriteColor>(
-    config: &BuildConfig,
-    mutant_file: &Path,
-    original_file: &Path,
-    package_path: &Path,
-    prover_conf: &move_prover::cli::Options,
-    outdir_prove: &Path,
-    mut error_writer: &mut W,
-) -> anyhow::Result<()> {
-    debug!("Original file: {:?}", original_file);
-    debug!("Mutant file: {:?}", mutant_file);
-
-    let _ = fs::remove_dir_all(&outdir_prove);
-    move_mutator::compiler::copy_dir_all(&package_path, &outdir_prove)?;
-
-    trace!(
-        "Copying mutant file {:?} to the package directory {:?}",
-        mutant_file,
-        outdir_prove.join(original_file)
-    );
-
-    if let Err(res) = fs::copy(mutant_file, outdir_prove.join(original_file)) {
-        let msg = format!("Can't copy mutant file to the package directory: {:?}", res);
-        warn!("{msg}");
-        return Err(anyhow!(msg));
-    }
-
-    prove(&config, &outdir_prove, &prover_conf, &mut error_writer)
-}
 
 /// The `prove` function is responsible for proving the package.
 ///


### PR DESCRIPTION
### Description

This PR reads the produced report (mutator report) and calls Move Prover on each mutated file.

Made some minor tweaks to the mutator tool to be able to access some of its functions that can be used in other tools, like `spec-test`.
    
Added new test case where mutated code will pass the specification.
