### PR TITLE
[move-mutator] updates

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 pretty_env_logger = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-tempfile = "3.8"
+tempfile = "3.9"
 toml = "0.5"
 
 move-command-line-common = { path = "../../move-command-line-common" }

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 pub const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
 
 /// Command line options for mutator
-#[derive(Parser, Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Parser, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Options {
     /// The paths to the Move sources.
@@ -32,4 +32,22 @@ pub struct Options {
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
+}
+
+impl Default for Options {
+    // We need to implement default just because we need to specify the default value for out_mutant_dir.
+    // Otherwise, out_mutant_dir would be empty. This is special case, when user won't specify any Options
+    // (so the default value would be used), but define package_path (which is passed using other mechanism).
+    fn default() -> Self {
+        Self {
+            move_sources: vec![],
+            include_only_files: None,
+            exclude_files: None,
+            out_mutant_dir: PathBuf::from(DEFAULT_OUTPUT_DIR),
+            verify_mutants: true,
+            no_overwrite: None,
+            downsample_filter: None,
+            configuration_file: None,
+        }
+    }
 }

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -21,7 +21,7 @@ pub struct Options {
     #[clap(long, short, value_parser, default_value = DEFAULT_OUTPUT_DIR)]
     pub out_mutant_dir: PathBuf,
     /// Indicates if mutants should be verified and made sure mutants can compile.
-    #[clap(long, default_value = "true")]
+    #[clap(long, default_value = "false")]
     pub verify_mutants: bool,
     /// Indicates if the output files should be overwritten.
     #[clap(long, short)]

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -18,8 +18,8 @@ pub struct Options {
     #[clap(long, short, value_parser)]
     pub exclude_files: Option<Vec<PathBuf>>,
     /// The path where to put the output files.
-    #[clap(long, short, value_parser, default_value = DEFAULT_OUTPUT_DIR)]
-    pub out_mutant_dir: PathBuf,
+    #[clap(long, short, value_parser)]
+    pub out_mutant_dir: Option<PathBuf>,
     /// Indicates if mutants should be verified and made sure mutants can compile.
     #[clap(long, default_value = "false")]
     pub verify_mutants: bool,
@@ -43,7 +43,7 @@ impl Default for Options {
             move_sources: vec![],
             include_only_files: None,
             exclude_files: None,
-            out_mutant_dir: PathBuf::from(DEFAULT_OUTPUT_DIR),
+            out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: true,
             no_overwrite: None,
             downsample_filter: None,

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -34,14 +34,21 @@ use move_package::BuildConfig;
 pub fn generate_ast(
     mutator_config: &Configuration,
     config: &BuildConfig,
-    _package_path: PathBuf,
+    package_path: PathBuf,
 ) -> Result<(FilesSourceText, move_compiler::parser::ast::Program), anyhow::Error> {
-    let source_files = mutator_config
+    let mut source_files = mutator_config
         .project
         .move_sources
         .iter()
         .map(|p| p.to_str().unwrap_or(""))
         .collect::<Vec<_>>();
+
+    // If -m option is specified we should only `move_sources`. However, if `move_sources` is empty
+    // we should add a package path. This path should be always set by the calling function.
+    // In case of any error we should use current directory as package root.
+    if source_files.is_empty() {
+        source_files.push(package_path.to_str().unwrap_or("."));
+    }
 
     debug!("Source files and folders: {:?}", source_files);
 

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+use crate::cli;
 use crate::configuration::Configuration;
 use move_compiler::diagnostics::FilesSourceText;
 use move_compiler::{
@@ -67,6 +68,8 @@ pub fn generate_ast(
     let interface_files_dir = mutator_config
         .project
         .out_mutant_dir
+        .clone()
+        .unwrap_or(PathBuf::from(cli::DEFAULT_OUTPUT_DIR))
         .join("generated_interface_files/mutator_build");
     let flags = Flags::empty();
 

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -169,7 +169,7 @@ pub fn verify_mutant(
 /// # Returns
 ///
 /// * `io::Result<()>` - Ok if the copy is successful, or an error if any error occurs.
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     if !dst.as_ref().exists() {
         fs::create_dir_all(dst.as_ref())?;
     }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -154,8 +154,8 @@ fn setup_mutant_path(output_dir: &Path, filename: &str, index: u64) -> PathBuf {
 ///
 /// * `anyhow::Result<PathBuf>` - Returns the path to the output directory if successful, or an error if any error occurs.
 fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow::Result<PathBuf> {
-    trace!("Setting up output directory");
     let output_dir = mutator_configuration.project.out_mutant_dir.clone();
+    trace!("Trying to set up output directory to: {:?}", output_dir);
 
     // Check if output directory exists and if it should be overwritten
     if output_dir.exists() && mutator_configuration.project.no_overwrite.unwrap_or(false) {

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -3,7 +3,7 @@ extern crate pretty_env_logger;
 extern crate log;
 
 pub mod cli;
-mod compiler;
+pub mod compiler;
 
 mod mutate;
 
@@ -11,7 +11,7 @@ mod configuration;
 mod mutant;
 mod operator;
 mod output;
-mod report;
+pub mod report;
 
 use crate::compiler::{generate_ast, verify_mutant};
 use std::fs;

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -7,7 +7,7 @@ pub mod compiler;
 
 mod mutate;
 
-mod configuration;
+pub mod configuration;
 mod mutant;
 mod operator;
 mod output;

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -37,7 +37,9 @@ pub fn run_move_mutator(
     config: BuildConfig,
     package_path: PathBuf,
 ) -> anyhow::Result<()> {
-    pretty_env_logger::init();
+    // We need to initialize logger using try_init() as it might be already initialized in some other tool
+    // (e.g. spec-test). If we use init() instead, we will get an abort.
+    let _ = pretty_env_logger::try_init();
 
     info!(
         "Executed move-mutator with the following options: {:?} \n config: {:?} \n package path: {:?}",

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -10,6 +10,16 @@ use std::path::{Path, PathBuf};
 /// This function recognizes if the file is inside a package and creates the directory structure
 /// according to its relative path inside the package. If the file is not inside any package,
 /// it creates the directory structure in the output directory.
+/// Example:
+/// The file to be mutated is located in "/a/b/c/sources/X/Y/file.move" (file_path).
+/// This function constructs the following output path for file.move:
+/// "output_dir/X/Y/file_index.move"
+/// It finds the package root for the file, which is "/a/b/c", then it append the relative path to the output directory.
+///
+/// If the file is not inside any package, it creates the directory structure in the output directory like:
+/// The file to be mutated is located in "/a/b/c/file.move" (file_path).
+/// This function constructs the following output path for file.move:
+/// "output_dir/file_index.move"
 ///
 /// # Arguments
 ///
@@ -37,8 +47,8 @@ pub(crate) fn setup_mutant_path(
     let root = SourcePackageLayout::try_find_root(&file_path_canonicalized);
     let root_path = if let Err(e) = root {
         debug!(
-            "Cannot find package root for {:?}. Error: {:?}. Assuming mutating single file.",
-            file_path_canonicalized, e
+            "No package root for {:?}. Assuming mutating a single file.",
+            file_path_canonicalized
         );
         file_path_canonicalized.clone()
     } else {

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -1,0 +1,219 @@
+use crate::configuration::Configuration;
+use move_package::source_package::layout::SourcePackageLayout;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Sets up the path for the mutant.
+///
+/// It creates the directory structure for the mutant and returns the path to the mutant.
+/// This function recognizes if the file is inside a package and creates the directory structure
+/// according to its relative path inside the package. If the file is not inside any package,
+/// it creates the directory structure in the output directory.
+///
+/// # Arguments
+///
+/// * `output_dir` - The directory where the mutant will be output.
+/// * `filename` - The path to the original file.
+/// * `index` - The index of the mutant.
+///
+/// # Returns
+///
+/// * `PathBuf` - The path to the mutant.
+pub(crate) fn setup_mutant_path(
+    output_dir: &Path,
+    file_path: &Path,
+    index: u64,
+) -> anyhow::Result<PathBuf> {
+    trace!(
+        "Trying to set up mutant path for {:?} with index {}",
+        file_path,
+        index
+    );
+
+    let file_path_canonicalized = file_path.canonicalize()?;
+
+    // Try to find package root for the file. If the file is not inside any package, assume that it is a single file
+    let root = SourcePackageLayout::try_find_root(&file_path_canonicalized);
+    let root_path = if let Err(e) = root {
+        debug!(
+            "Cannot find package root for {:?}. Error: {:?}. Assuming mutating single file.",
+            file_path_canonicalized, e
+        );
+        file_path_canonicalized.clone()
+    } else {
+        // In case of file is inside the package it must follow the Move structure. So we can assume that
+        // there will be a sources directory inside the package root. We can omit it.
+        root?.join("sources")
+    };
+
+    // Stripping whole prefix before file to get it relative path inside the package
+    let relative_path = file_path_canonicalized.strip_prefix(&root_path)?;
+
+    // Construct the directory structure for that specified file in the output directory. If file was inside the package,
+    // parent() will return its relative folder path inside the package. If file was outside any package, parent() will return None.
+    let output_struct = output_dir.join(relative_path.parent().unwrap_or(Path::new("")));
+
+    // Create the directory structure for that specified file in the output directory. Ignore errors if the directory already exists.
+    if let Err(e) = fs::create_dir_all(&output_struct) {
+        if e.kind() != std::io::ErrorKind::AlreadyExists {
+            let error_msg = format!(
+                "Cannot create directory structure for {:?}. Error: {:?}",
+                output_struct, e
+            );
+            error!("{error_msg}");
+            return Err(anyhow::anyhow!(error_msg));
+        }
+    }
+
+    let filename = file_path
+        .file_stem()
+        .ok_or(anyhow::anyhow!("Cannot get file stem of {:?}", file_path))?;
+
+    // Deal with the file as OsString to avoid problems with non-UTF8 characters
+    let mut filename = filename.to_os_string();
+    filename.push(OsString::from(format!("_{}.move", index)));
+
+    Ok(output_struct.join(filename))
+}
+
+/// Sets up the output directory for the mutants.
+///
+/// # Arguments
+///
+/// * `mutator_configuration` - The configuration for the mutator.
+///
+/// # Returns
+///
+/// * `anyhow::Result<PathBuf>` - Returns the path to the output directory if successful, or an error if any error occurs.
+pub(crate) fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow::Result<PathBuf> {
+    let output_dir = mutator_configuration.project.out_mutant_dir.clone();
+    trace!("Trying to set up output directory to: {:?}", output_dir);
+
+    // Check if output directory exists and if it should be overwritten
+    if output_dir.exists() && mutator_configuration.project.no_overwrite.unwrap_or(false) {
+        return Err(anyhow::anyhow!(
+            "Output directory already exists. Use --no-overwrite=false to overwrite."
+        ));
+    }
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+    std::fs::create_dir(&output_dir)?;
+
+    debug!("Output directory set to: {:?}", output_dir);
+
+    Ok(output_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli;
+    use std::fs;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn setup_mutant_path_handles_non_utf8_characters() {
+        let output_dir = Path::new("mutants_output");
+        let filename = Path::new("💖");
+        fs::File::create(filename).unwrap();
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        fs::remove_file(filename).unwrap();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), PathBuf::from("mutants_output/💖_1.move"));
+    }
+
+    #[test]
+    fn setup_mutant_path_handles_file_without_extension() {
+        let output_dir = Path::new("mutants_output");
+        let filename = Path::new("file1");
+        fs::File::create(filename).unwrap();
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        fs::remove_file(filename).unwrap();
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            PathBuf::from("mutants_output/file1_1.move")
+        );
+    }
+
+    #[test]
+    fn setup_mutant_path_creates_correct_path() {
+        let output_dir = Path::new("mutants_output");
+        let filename = Path::new("test");
+        fs::File::create(filename).unwrap();
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        fs::remove_file(filename).unwrap();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), PathBuf::from("mutants_output/test_1.move"));
+    }
+
+    #[test]
+    fn setup_mutant_path_handles_empty_output_dir() {
+        let output_dir = Path::new("");
+        let filename = Path::new("test");
+        fs::File::create(filename).unwrap();
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        fs::remove_file(filename).unwrap();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), PathBuf::from("test_1.move"));
+    }
+
+    #[test]
+    fn setup_mutant_path_handles_empty_filename() {
+        let output_dir = Path::new("mutants_output");
+        let filename = Path::new("");
+        let index = 1;
+        let result = setup_mutant_path(output_dir, filename, index);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn setup_output_dir_creates_directory_if_not_exists() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        let options = cli::Options {
+            out_mutant_dir: output_dir.clone(),
+            no_overwrite: Some(false),
+            ..Default::default()
+        };
+        let config = Configuration::new(options, None);
+        assert!(setup_output_dir(&config).is_ok());
+        assert!(output_dir.exists());
+    }
+
+    #[test]
+    fn setup_output_dir_overwrites_directory_if_exists_and_no_overwrite_is_false() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        fs::create_dir(&output_dir).unwrap();
+        let options = cli::Options {
+            out_mutant_dir: output_dir.clone(),
+            no_overwrite: Some(false),
+            ..Default::default()
+        };
+        let config = Configuration::new(options, None);
+        assert!(setup_output_dir(&config).is_ok());
+        assert!(output_dir.exists());
+    }
+
+    #[test]
+    fn setup_output_dir_errors_if_directory_exists_and_no_overwrite_is_true() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        fs::create_dir(&output_dir).unwrap();
+        let options = cli::Options {
+            out_mutant_dir: output_dir.clone(),
+            no_overwrite: Some(true),
+            ..Default::default()
+        };
+        let config = Configuration::new(options, None);
+        assert!(setup_output_dir(&config).is_err());
+    }
+}

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::io::Write;
+use std::io::{Error, ErrorKind, Result, Write};
 use std::path::{Path, PathBuf};
 
 /// The `Report` struct represents a report of mutations.
@@ -26,26 +26,25 @@ impl Report {
     }
 
     /// Saves the `Report` as a JSON file.
-    pub fn save_to_json_file(&self, path: &Path) -> std::io::Result<()> {
+    pub fn save_to_json_file(&self, path: &Path) -> Result<()> {
         let file = std::fs::File::create(path)?;
 
         info!("Saving report to {}", path.display());
 
-        serde_json::to_writer_pretty(file, &self)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        serde_json::to_writer_pretty(file, &self).map_err(|e| Error::new(ErrorKind::Other, e))
     }
 
     /// Loads the `Report` from a JSON file.
-    pub fn load_from_json_file(path: &Path) -> std::io::Result<Self> {
+    pub fn load_from_json_file(path: &Path) -> Result<Self> {
         info!("Reading report from {}", path.display());
 
         let file = std::fs::File::open(path)?;
 
-        serde_json::from_reader(file).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        serde_json::from_reader(file).map_err(|e| Error::new(ErrorKind::Other, e))
     }
 
     /// Saves the `Report` as a text file.
-    pub fn save_to_text_file(&self, path: &Path) -> std::io::Result<()> {
+    pub fn save_to_text_file(&self, path: &Path) -> Result<()> {
         let mut file = std::fs::File::create(path)?;
 
         info!("Saving report to {}", path.display());
@@ -175,13 +174,13 @@ impl MutationReport {
         self.mutations.push(modification);
     }
 
-    /// Return the mutant path
-    pub fn get_mutant_path(&self) -> &PathBuf {
+    /// Return the mutant path.
+    pub fn mutant_path(&self) -> &PathBuf {
         &self.mutant_path
     }
 
-    /// Return the original file path
-    pub fn get_original_file_path(&self) -> &PathBuf {
+    /// Return the original file path.
+    pub fn original_file_path(&self) -> &PathBuf {
         &self.original_file
     }
 }

--- a/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/Sub.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/Sub.move
@@ -1,0 +1,10 @@
+module Test::Sub {
+    fun sub(x: u128, y: u128): u128 {
+        let sub_r = x - y;
+        spec {
+                assert sub_r == x-y;
+        };
+
+        sub_r
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "poor_spec"
+version = "0.0.0"
+
+[addresses]
+TestAccount = "0xCAFE"

--- a/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
@@ -1,0 +1,12 @@
+module TestAccount::Sum {
+    fun sum(x: u128, y: u128): u128 {
+        let sum_r = x + y;
+
+        spec {
+                // Senseless specification
+                assert sum_r >= 0;
+        };
+
+        sum_r
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/poor_spec/sources/Sum.move
@@ -3,7 +3,7 @@ module TestAccount::Sum {
         let sum_r = x + y;
 
         spec {
-                // Senseless specification
+                // Senseless specification - mutator will change + operator to -*/ but spec won't notice it.
                 assert sum_r >= 0;
         };
 

--- a/third_party/move/tools/move-mutator/tests/move-assets/same_names/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/same_names/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "same_names"
+version = "0.0.0"
+
+[addresses]
+TestAccount = "0xCAFE"

--- a/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/Negation.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/Negation.move
@@ -1,0 +1,9 @@
+module TestAccount::Negation_main {
+    fun neg_log(x: bool): bool {
+        !x
+    }
+
+    spec neg_log {
+        ensures result == !x;
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/m1/Negation.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/m1/Negation.move
@@ -1,0 +1,9 @@
+module TestAccount::Negation_m1 {
+    fun neg_log(x: bool): bool {
+        !x
+    }
+
+    spec neg_log {
+        ensures result == !x;
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/m1/m1_1/Negation.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/m1/m1_1/Negation.move
@@ -1,0 +1,9 @@
+module TestAccount::Negation_m1_1 {
+    fun neg_log(x: bool): bool {
+        !x
+    }
+
+    spec neg_log {
+        ensures result == !x;
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/m2/Negation.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/same_names/sources/m2/Negation.move
@@ -1,0 +1,9 @@
+module TestAccount::Negation_m2 {
+    fun neg_log(x: bool): bool {
+        !x
+    }
+
+    spec neg_log {
+        ensures result == !x;
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces changes to the mutator tool needed to co-operate with `spec-test` correctly.

The main part concerns changing the output directory structure. The tool now creates a new directory structure for the mutant and introduces an enhanced function that returns the path to the mutant. That function recognizes if the file is inside a package and creates the directory structure according to its relative path inside the package. If the file is not inside any package, it creates the directory structure in the output directory.
Example:
The original file to be mutated is located in "/a/b/c/sources/X/Y/file.move".
The new function constructs the following output path for `file.move`:
"output_dir/X/Y/file_index.move"
It finds the file's package root, "/a/b/c", and then it appends the relative path to the output directory.
If the file is not inside any package, it creates the directory structure in the output directory like:
The file to be mutated is located in "/a/b/c/file.move".
The new function constructs the following output path for `file.move`:
"output_dir/file_index.move"

There are also several minor changes:
- make use of the package path passed to the mutator;
- update dependencies
- the correct way of initializing the logger
- change the visibility of several functions to be re-used in `spec-test`

### Test Plan
Unit tests have been updated to reflect changes in this PR.
New test assets have been added:
- `poor_spec` - test with the badly written specification, which should let mutants pass the proving process
- `same_names` - test where files have the same names but are placed under different subdirectories under the `sources` directory
- `file_without_package` - test for mutating file which does not belong to any package
