### PR TITLE
[move-spec-test] initial `spec-test` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ members = [
     "third_party/move/tools/move-mutator",
     "third_party/move/tools/move-package",
     "third_party/move/tools/move-resource-viewer",
+    "third_party/move/tools/move-spec-test",
     "third_party/move/tools/move-unit-test",
     "types",
     "vm-validator",
@@ -719,6 +720,7 @@ move-package = { path = "third_party/move/tools/move-package" }
 move-prover = { path = "third_party/move/move-prover" }
 move-prover-boogie-backend = { path = "third_party/move/move-prover/boogie-backend" }
 move-prover-bytecode-pipeline = { path = "third_party/move/move-prover/bytecode-pipeline" }
+move-spec-test = { path = "third_party/move/tools/move-spec-test" }
 move-stackless-bytecode = { path = "third_party/move/move-model/bytecode" }
 move-stackless-bytecode-test-utils = { path = "third_party/move/move-model/bytecode-test-utils" }
 aptos-move-stdlib = { path = "aptos-move/framework/move-stdlib" }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -75,6 +75,7 @@ move-disassembler = { workspace = true }
 move-ir-types = { workspace = true }
 move-mutator = { workspace = true }
 move-package = { workspace = true }
+move-spec-test = { workspace = true }
 move-symbol-pool = { workspace = true }
 move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -113,6 +113,8 @@ pub enum CliError {
     CoverageError(String),
     #[error("Move mutator failed: {0}")]
     MoveMutatorError(String),
+    #[error("Move spec-test failed: {0}")]
+    MoveSpecTestError(String),
 }
 
 impl CliError {
@@ -134,6 +136,7 @@ impl CliError {
             CliError::UnexpectedError(_) => "UnexpectedError",
             CliError::SimulationError(_) => "SimulationError",
             CliError::CoverageError(_) => "CoverageError",
+            CliError::MoveSpecTestError(_) => "MoveSpecTestError",
         }
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -92,6 +92,7 @@ pub enum MoveTool {
     RunScript(RunScript),
     #[clap(subcommand, hide = true)]
     Show(show::ShowTool),
+    SpecTest(SpecTestPackage),
     Test(TestPackage),
     VerifyPackage(VerifyPackage),
     View(ViewFunction),
@@ -119,6 +120,7 @@ impl MoveTool {
             MoveTool::Run(tool) => tool.execute_serialized().await,
             MoveTool::RunScript(tool) => tool.execute_serialized().await,
             MoveTool::Show(tool) => tool.execute_serialized().await,
+            MoveTool::SpecTest(tool) => tool.execute_serialized().await,
             MoveTool::Test(tool) => tool.execute_serialized().await,
             MoveTool::VerifyPackage(tool) => tool.execute_serialized().await,
             MoveTool::View(tool) => tool.execute_serialized().await,
@@ -555,16 +557,69 @@ impl CliCommand<&'static str> for MutatePackage {
 
         let path = self.move_options.get_package_path()?;
 
-        let result = move_mutator::run_move_mutator(
-            mutator_options.unwrap_or_default(),
-            config,
-            path,
-        )
-        .map_err(|err| CliError::UnexpectedError(err.to_string()));
+        let result =
+            move_mutator::run_move_mutator(mutator_options.unwrap_or_default(), config, path)
+                .map_err(|err| CliError::UnexpectedError(err.to_string()));
 
         match result {
             Ok(_) => Ok("Success"),
             Err(e) => Err(CliError::MoveMutatorError(format!("{:#}", e))),
+        }
+    }
+}
+
+/// Test specification of a Move package.
+#[derive(Parser)]
+pub struct SpecTestPackage {
+    /// Options for parsing and compiling a move package dir
+    #[clap(flatten)]
+    move_options: MovePackageDir,
+    /// Options specific for the spec-test tool
+    #[clap(flatten)]
+    spec_test_options: Option<move_spec_test::cli::Options>,
+}
+
+#[async_trait]
+impl CliCommand<&'static str> for SpecTestPackage {
+    /// Returns the name of the command used in the CLI.
+    fn command_name(&self) -> &'static str {
+        "SpecTestPackage"
+    }
+
+    /// Executes the spec-test command. Internally, it generates mutants with the provided parameters and passes them to the
+    /// Prover.
+    async fn execute(self) -> CliTypedResult<&'static str> {
+        let crate::move_tool::SpecTestPackage {
+            move_options: _,
+            spec_test_options,
+        } = self;
+
+        let known_attributes = extended_checks::get_all_attribute_names();
+        let config = BuildConfig {
+            dev_mode: self.move_options.dev,
+            additional_named_addresses: self.move_options.named_addresses(),
+            test_mode: false,
+            full_model_generation: self.move_options.check_test_code,
+            install_dir: self.move_options.output_dir.clone(),
+            skip_fetch_latest_git_deps: self.move_options.skip_fetch_latest_git_deps,
+            compiler_config: CompilerConfig {
+                known_attributes: known_attributes.clone(),
+                skip_attribute_checks: self.move_options.skip_attribute_checks,
+                compiler_version: self.move_options.compiler_version,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let path = self.move_options.get_package_path()?;
+
+        let result =
+            move_spec_test::run_spec_test(spec_test_options.unwrap_or_default(), config, path)
+                .map_err(|err| CliError::UnexpectedError(err.to_string()));
+
+        match result {
+            Ok(_) => Ok("Success"),
+            Err(e) => Err(CliError::MoveSpecTestError(format!("{:#}", e))),
         }
     }
 }

--- a/third_party/move/tools/move-cli/Cargo.toml
+++ b/third_party/move/tools/move-cli/Cargo.toml
@@ -46,6 +46,7 @@ move-mutator = { path = "../move-mutator" }
 move-package = { path = "../move-package" }
 move-prover = { path = "../../move-prover" }
 move-resource-viewer = { path = "../move-resource-viewer" }
+move-spec-test = { path = "../move-spec-test" }
 move-stdlib = { path = "../../move-stdlib" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-table-extension = { path = "../../extensions/move-table-extension", optional = true }

--- a/third_party/move/tools/move-cli/src/base/mod.rs
+++ b/third_party/move/tools/move-cli/src/base/mod.rs
@@ -11,6 +11,7 @@ pub mod movey_upload;
 pub mod mutate;
 pub mod new;
 pub mod prove;
+pub mod spec_test;
 pub mod test;
 pub mod test_validation;
 

--- a/third_party/move/tools/move-cli/src/base/spec_test.rs
+++ b/third_party/move/tools/move-cli/src/base/spec_test.rs
@@ -1,0 +1,28 @@
+use clap::*;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+/// Test the Move specification using the Move Mutator and Move Prover
+#[derive(Parser)]
+#[clap(name = "spec-test")]
+pub struct SpecTest {
+    /// Any options passed to the move-spec-test
+    #[clap(flatten)]
+    pub options: Option<move_spec_test::cli::Options>,
+}
+
+impl SpecTest {
+    /// Executes the spec-test command which produces mutants from the Move files or package using
+    /// the provided configuration. Then it passes the mutants to the Move prover to check if the
+    /// mutants are killed by the prover.
+    /// If no path is provided, the current directory is used.
+    pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
+        let path = path.unwrap_or_else(|| PathBuf::from("."));
+
+        let Self { options } = self;
+
+        let options = options.unwrap_or_default();
+
+        move_spec_test::run_spec_test(options, config, path)
+    }
+}

--- a/third_party/move/tools/move-cli/src/base/spec_test.rs
+++ b/third_party/move/tools/move-cli/src/base/spec_test.rs
@@ -1,6 +1,7 @@
 use clap::*;
 use move_package::BuildConfig;
 use std::path::PathBuf;
+use crate::base::reroot_path;
 
 /// Test the Move specification using the Move Mutator and Move Prover
 #[derive(Parser)]
@@ -17,12 +18,12 @@ impl SpecTest {
     /// mutants are killed by the prover.
     /// If no path is provided, the current directory is used.
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
-        let path = path.unwrap_or_else(|| PathBuf::from("."));
+        let rerooted_path = reroot_path(path)?;
 
         let Self { options } = self;
 
         let options = options.unwrap_or_default();
 
-        move_spec_test::run_spec_test(options, config, path)
+        move_spec_test::run_spec_test(options, config, rerooted_path)
     }
 }

--- a/third_party/move/tools/move-cli/src/lib.rs
+++ b/third_party/move/tools/move-cli/src/lib.rs
@@ -4,7 +4,7 @@
 
 use base::{
     build::Build, coverage::Coverage, disassemble::Disassemble, docgen::Docgen, errmap::Errmap,
-    movey_login::MoveyLogin, movey_upload::MoveyUpload, mutate::Mutate, new::New, prove::Prove, test::Test,
+    movey_login::MoveyLogin, movey_upload::MoveyUpload, mutate::Mutate, new::New, prove::Prove, spec_test::SpecTest, test::Test,
 };
 use move_package::BuildConfig;
 
@@ -71,6 +71,7 @@ pub enum Command {
     Mutate(Mutate),
     New(New),
     Prove(Prove),
+    SpecTest(SpecTest),
     Test(Test),
     /// Execute a sandbox command.
     #[clap(name = "sandbox")]
@@ -106,6 +107,7 @@ pub fn run_cli(
         Command::Mutate(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::New(c) => c.execute_with_defaults(move_args.package_path),
         Command::Prove(c) => c.execute(move_args.package_path, move_args.build_config),
+        Command::SpecTest(c) => c.execute(move_args.package_path, move_args.build_config),
         Command::Test(c) => c.execute(
             move_args.package_path,
             move_args.build_config,

--- a/third_party/move/tools/move-spec-test/Cargo.toml
+++ b/third_party/move/tools/move-spec-test/Cargo.toml
@@ -18,6 +18,8 @@ clap = { version = "4.3", features = ["derive"] }
 log = "0.4"
 pretty_env_logger = "0.5"
 serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.9"
+termcolor = "1.1"
 
 move-command-line-common = { path = "../../move-command-line-common" }
 move-mutator = { path = "../move-mutator" }

--- a/third_party/move/tools/move-spec-test/Cargo.toml
+++ b/third_party/move/tools/move-spec-test/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "move-spec-test"
+version = "0.1.0"
+authors = ["Eiger <hello@eiger.co>"]
+
+description = "Move specification testing tool"
+
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.3", features = ["derive"] }
+log = "0.4"
+pretty_env_logger = "0.5"
+serde = { version = "1.0", features = ["derive"] }
+
+move-command-line-common = { path = "../../move-command-line-common" }
+move-mutator = { path = "../move-mutator" }
+move-package = { path = "../move-package" }
+move-prover = { path = "../../move-prover" }

--- a/third_party/move/tools/move-spec-test/README.md
+++ b/third_party/move/tools/move-spec-test/README.md
@@ -1,0 +1,1 @@
+# Move Specification Test tool

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -25,3 +25,34 @@ pub struct Options {
     #[clap(long, value_parser)]
     pub extra_prover_args: Option<Vec<String>>,
 }
+
+/// This function creates a mutator CLI options from the given spec-test options.
+/// It clones the move_sources, include_only_files, exclude_files, and configuration_file from the given options.
+/// The rest of the options are set to default.
+pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
+    move_mutator::cli::Options {
+        move_sources: options.move_sources.clone(),
+        include_only_files: options.include_only_files.clone(),
+        exclude_files: options.exclude_files.clone(),
+        configuration_file: options.mutator_conf.clone(),
+        ..Default::default()
+    }
+}
+
+/// This function generates a prover CLI options from the given spec-test options.
+/// It first checks if a prover configuration file is provided in the options.
+/// If it is, it creates the prover options from the configuration file.
+/// If it is not, it checks if extra prover arguments are provided in the options.
+/// If they are, it creates the prover options from the arguments.
+/// Otherwise, it creates the default prover options.
+pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover::cli::Options> {
+    let prover_conf = if let Some(conf) = &options.prover_conf {
+        move_prover::cli::Options::create_from_toml_file(conf.to_str().unwrap_or(""))?
+    } else if let Some(args) = &options.extra_prover_args {
+        move_prover::cli::Options::create_from_args(args)?
+    } else {
+        move_prover::cli::Options::default()
+    };
+
+    Ok(prover_conf)
+}

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -27,8 +27,6 @@ pub struct Options {
 }
 
 /// This function creates a mutator CLI options from the given spec-test options.
-/// It clones the move_sources, include_only_files, exclude_files, and configuration_file from the given options.
-/// The rest of the options are set to default.
 pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
     move_mutator::cli::Options {
         move_sources: options.move_sources.clone(),
@@ -40,11 +38,6 @@ pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
 }
 
 /// This function generates a prover CLI options from the given spec-test options.
-/// It first checks if a prover configuration file is provided in the options.
-/// If it is, it creates the prover options from the configuration file.
-/// If it is not, it checks if extra prover arguments are provided in the options.
-/// If they are, it creates the prover options from the arguments.
-/// Otherwise, it creates the default prover options.
 pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover::cli::Options> {
     let prover_conf = if let Some(conf) = &options.prover_conf {
         move_prover::cli::Options::create_from_toml_file(conf.to_str().unwrap_or(""))?
@@ -55,4 +48,18 @@ pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover:
     };
 
     Ok(prover_conf)
+}
+
+/// This function checks if the mutator output path is provided in the configuration file.
+/// We don't need to check if the mutator output path is provided in the options as they were created
+/// from the spec-test options which does not allow to set it..
+pub fn check_mutator_output_path(options: &move_mutator::cli::Options) -> Option<PathBuf> {
+    if let Some(conf) = &options.configuration_file {
+        let c = move_mutator::configuration::Configuration::from_file(conf);
+        if let Ok(c) = c {
+            return c.project.out_mutant_dir;
+        }
+    };
+
+    None
 }

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -1,0 +1,27 @@
+use clap::*;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Command line options for specification test tool.
+#[derive(Parser, Default, Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Options {
+    /// The paths to the Move sources.
+    #[clap(long, short, value_parser)]
+    pub move_sources: Vec<PathBuf>,
+    /// The paths to the Move sources to include.
+    #[clap(long, short, value_parser)]
+    pub include_only_files: Option<Vec<PathBuf>>,
+    /// The paths to the Move sources to exclude.
+    #[clap(long, short, value_parser)]
+    pub exclude_files: Option<Vec<PathBuf>>,
+    /// Optional configuration file for mutator tool.
+    #[clap(long, value_parser)]
+    pub mutator_conf: Option<PathBuf>,
+    /// Optional configuration file for prover tool.
+    #[clap(long, value_parser)]
+    pub prover_conf: Option<PathBuf>,
+    /// Extra arguments to pass to the prover.
+    #[clap(long, value_parser)]
+    pub extra_prover_args: Option<Vec<String>>,
+}

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -1,9 +1,12 @@
 pub mod cli;
+mod prover;
 
 extern crate pretty_env_logger;
 #[macro_use]
 extern crate log;
 
+use crate::prover::prove;
+use anyhow::anyhow;
 use move_package::BuildConfig;
 use std::path::PathBuf;
 
@@ -24,15 +27,79 @@ use std::path::PathBuf;
 ///
 /// * `anyhow::Result<()>` - The result of the spec test.
 pub fn run_spec_test(
-    _options: cli::Options,
-    _config: BuildConfig,
-    _package_path: PathBuf,
+    options: cli::Options,
+    config: BuildConfig,
+    package_path: PathBuf,
 ) -> anyhow::Result<()> {
-    pretty_env_logger::init();
+    // We need to initialize logger using try_init() as it might be already initialized in some other tool
+    // (e.g. spec-test). If we use init() instead, we will get an abort.
+    let _ = pretty_env_logger::try_init();
 
     info!("Running spec test");
 
-    // TODO: implement
+    let mut mutator_conf = cli::create_mutator_options(&options);
+    let prover_conf = cli::generate_prover_options(&options)?;
+
+    // Setup temporary directory structure
+    let outdir = tempfile::tempdir()?.into_path();
+    let outdir_mutant = outdir.join("mutants");
+    let outdir_original = outdir.join("base");
+
+    std::fs::create_dir_all(&outdir_mutant)?;
+    std::fs::create_dir_all(&outdir_original)?;
+
+    mutator_conf.out_mutant_dir = outdir_mutant.clone();
+
+    debug!("Running the move mutator tool");
+
+    move_mutator::run_move_mutator(mutator_conf, config.clone(), package_path.clone())?;
+
+    let report =
+        move_mutator::report::Report::load_from_json_file(&outdir_mutant.join("report.json"))?;
+
+    // Proving part
+    move_mutator::compiler::copy_dir_all(&package_path, &outdir_original)?;
+
+    let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
+
+    let result = prove(&config, &package_path, &prover_conf, &mut error_writer);
+
+    if let Err(e) = result {
+        let msg = format!(
+            "Original code verification failed! Prover failed with error: {}",
+            e
+        );
+        error!("{msg}");
+        return Err(anyhow!(msg));
+    }
+
+    // TODO: change this to report generation
+    let mut total_mutants = 0;
+    let mut killed_mutants = 0;
+
+    for elem in report.get_mutants() {
+        total_mutants += 1;
+
+        let result = prover::prove_mutant(
+            &config,
+            &elem.get_mutant_path(),
+            &elem.get_original_file_path(),
+            &package_path,
+            &prover_conf,
+            &outdir.join("prove"),
+            &mut error_writer,
+        );
+
+        if let Err(e) = result {
+            trace!("Mutant killed! Prover failed with error: {}", e);
+            killed_mutants += 1;
+        } else {
+            trace!("Mutant hasn't been killed!");
+        }
+    }
+
+    println!("Total mutants: {}", total_mutants);
+    println!("Killed mutants: {}", killed_mutants);
 
     Ok(())
 }

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -1,0 +1,38 @@
+pub mod cli;
+
+extern crate pretty_env_logger;
+#[macro_use]
+extern crate log;
+
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+/// This function runs the specification testing, which is a combination of the
+/// mutator tool and the prover tool
+/// It takes the CLI options and constructs appropriate options for the
+/// Move Mutator tool and Move Prover tool. Then it mutates the code storing
+/// results in a temporary directory. Then it runs the prover on the mutated
+/// code and remember the results, using them to generate the report at the end.
+///
+/// # Arguments
+///
+/// * `options` - A `cli::Options` representing the options for the spec test.
+/// * `config` - A `BuildConfig` representing the build configuration.
+/// * `package_path` - A `PathBuf` representing the path to the package.
+///
+/// # Returns
+///
+/// * `anyhow::Result<()>` - The result of the spec test.
+pub fn run_spec_test(
+    _options: cli::Options,
+    _config: BuildConfig,
+    _package_path: PathBuf,
+) -> anyhow::Result<()> {
+    pretty_env_logger::init();
+
+    info!("Running spec test");
+
+    // TODO: implement
+
+    Ok(())
+}

--- a/third_party/move/tools/move-spec-test/src/prover.rs
+++ b/third_party/move/tools/move-spec-test/src/prover.rs
@@ -1,0 +1,88 @@
+use anyhow::anyhow;
+use move_package::{BuildConfig, ModelConfig};
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+use termcolor::WriteColor;
+
+/// The `prove_mutant` function is responsible for setting up the output
+/// directory and calling function proving the mutant.
+///
+/// # Arguments
+///
+/// * `config` - A `BuildConfig` representing the build configuration.
+/// * `mutant_file` - `Path` the path to the mutant file.
+/// * `original_file` - `Path` the path to the original file.
+/// * `package_path` - `Path` the path to the package.
+/// * `prover_conf` - `move_prover::cli::Options` the options for the prover.
+/// * `outdir_prove` - `Path` the path to the output directory for proving.
+/// * `error_writer` - `&mut dyn std::io::Write` representing the error writer.
+///
+/// # Returns
+///
+/// * `anyhow::Result<()>` - The result of the proving process.
+pub(crate) fn prove_mutant<W: WriteColor>(
+    config: &BuildConfig,
+    mutant_file: &Path,
+    original_file: &Path,
+    package_path: &Path,
+    prover_conf: &move_prover::cli::Options,
+    outdir_prove: &Path,
+    mut error_writer: &mut W,
+) -> anyhow::Result<()> {
+    debug!("Original file: {:?}", original_file);
+    debug!("Mutant file: {:?}", mutant_file);
+
+    let _ = fs::remove_dir_all(&outdir_prove);
+    move_mutator::compiler::copy_dir_all(&package_path, &outdir_prove)?;
+
+    trace!(
+        "Copying mutant file {:?} to the package directory {:?}",
+        mutant_file,
+        outdir_prove.join(original_file)
+    );
+
+    if let Err(res) = fs::copy(mutant_file, outdir_prove.join(original_file)) {
+        let msg = format!("Can't copy mutant file to the package directory: {:?}", res);
+        warn!("{msg}");
+        return Err(anyhow!(msg));
+    }
+
+    prove(&config, &outdir_prove, &prover_conf, &mut error_writer)
+}
+
+/// The `prove` function is responsible for proving the package.
+///
+/// # Arguments
+///
+/// * `config` - A `BuildConfig` representing the build configuration.
+/// * `package_path` - A `Path` to the package.
+/// * `prover_conf` - `move_prover::cli::Options` the options for the prover.
+/// * `error_writer` - `&mut dyn std::io::Write` the error writer.
+///
+/// # Returns
+///
+/// * `anyhow::Result<()>` - The result of the proving process.
+pub(crate) fn prove<W: WriteColor>(
+    config: &BuildConfig,
+    package_path: &Path,
+    prover_conf: &move_prover::cli::Options,
+    mut error_writer: &mut W,
+) -> anyhow::Result<()> {
+    let model = config.clone().move_model_for_package(
+        package_path,
+        ModelConfig {
+            all_files_as_targets: true,
+            target_filter: None,
+        },
+    )?;
+
+    let now = Instant::now();
+
+    move_prover::run_move_prover_with_model(
+        &model,
+        &mut error_writer,
+        prover_conf.clone(),
+        Some(now),
+    )
+}

--- a/third_party/move/tools/move-spec-test/src/prover.rs
+++ b/third_party/move/tools/move-spec-test/src/prover.rs
@@ -1,55 +1,7 @@
-use anyhow::anyhow;
 use move_package::{BuildConfig, ModelConfig};
-use std::fs;
 use std::path::Path;
 use std::time::Instant;
 use termcolor::WriteColor;
-
-/// The `prove_mutant` function is responsible for setting up the output
-/// directory and calling function proving the mutant.
-///
-/// # Arguments
-///
-/// * `config` - A `BuildConfig` representing the build configuration.
-/// * `mutant_file` - `Path` the path to the mutant file.
-/// * `original_file` - `Path` the path to the original file.
-/// * `package_path` - `Path` the path to the package.
-/// * `prover_conf` - `move_prover::cli::Options` the options for the prover.
-/// * `outdir_prove` - `Path` the path to the output directory for proving.
-/// * `error_writer` - `&mut dyn std::io::Write` representing the error writer.
-///
-/// # Returns
-///
-/// * `anyhow::Result<()>` - The result of the proving process.
-pub(crate) fn prove_mutant<W: WriteColor>(
-    config: &BuildConfig,
-    mutant_file: &Path,
-    original_file: &Path,
-    package_path: &Path,
-    prover_conf: &move_prover::cli::Options,
-    outdir_prove: &Path,
-    mut error_writer: &mut W,
-) -> anyhow::Result<()> {
-    debug!("Original file: {:?}", original_file);
-    debug!("Mutant file: {:?}", mutant_file);
-
-    let _ = fs::remove_dir_all(&outdir_prove);
-    move_mutator::compiler::copy_dir_all(&package_path, &outdir_prove)?;
-
-    trace!(
-        "Copying mutant file {:?} to the package directory {:?}",
-        mutant_file,
-        outdir_prove.join(original_file)
-    );
-
-    if let Err(res) = fs::copy(mutant_file, outdir_prove.join(original_file)) {
-        let msg = format!("Can't copy mutant file to the package directory: {:?}", res);
-        warn!("{msg}");
-        return Err(anyhow!(msg));
-    }
-
-    prove(&config, &outdir_prove, &prover_conf, &mut error_writer)
-}
 
 /// The `prove` function is responsible for proving the package.
 ///


### PR DESCRIPTION
### Description

This PR allows running the specification testing process, which combines the mutator and prover tools. It takes the CLI options and constructs appropriate options for the Move Mutator and Move Prover tools. Then, it mutates the code, storing results in a temporary directory. Afterwards, it runs the prover on the mutated code and remembers the results, using them to generate the report at the end.

The basic info about the mutants killed is displayed right now. The next PRs within the third milestone will include a more detailed report.

The `spec-test` sub-command has been integrated into the `move` and `Aptos` commands.

### Test Plan
The mutator and prover tool tests can be reused to check this PR.
