### PR TITLE
[move-mutator][move-spec-test] milestone review remarks implementation and cleanup

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -622,7 +622,7 @@ impl CliCommand<&'static str> for SpecTestPackage {
             .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
         match result {
             Ok(_) => Ok("Success"),
-            Err(e) => Err(CliError::MoveProverError(format!("{:#}", e))),
+            Err(e) => Err(CliError::MoveSpecTestError(format!("{:#}", e))),
         }
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -521,7 +521,7 @@ pub struct MutatePackage {
     move_options: MovePackageDir,
     /// Options specific for the mutator tool
     #[clap(flatten)]
-    mutator_options: Option<move_mutator::cli::Options>,
+    mutator_options: Option<move_mutator::cli::CLIOptions>,
 }
 
 #[async_trait]
@@ -576,7 +576,7 @@ pub struct SpecTestPackage {
     move_options: MovePackageDir,
     /// Options specific for the spec-test tool
     #[clap(flatten)]
-    spec_test_options: Option<move_spec_test::cli::Options>,
+    spec_test_options: Option<move_spec_test::cli::CLIOptions>,
 }
 
 #[async_trait]

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -558,7 +558,7 @@ impl CliCommand<&'static str> for MutatePackage {
         let path = self.move_options.get_package_path()?;
 
         let result =
-            move_mutator::run_move_mutator(mutator_options.unwrap_or_default(), config, path)
+            move_mutator::run_move_mutator(mutator_options.unwrap_or_default(), &config, &path)
                 .map_err(|err| CliError::UnexpectedError(err.to_string()));
 
         match result {
@@ -612,14 +612,17 @@ impl CliCommand<&'static str> for SpecTestPackage {
         };
 
         let path = self.move_options.get_package_path()?;
+        let path = SourcePackageLayout::try_find_root(&path.canonicalize().unwrap_or(".".into()))?;
+        std::env::set_current_dir(&path).map_err(|err| CliError::UnexpectedError(err.to_string()))?;
 
-        let result =
-            move_spec_test::run_spec_test(spec_test_options.unwrap_or_default(), config, path)
-                .map_err(|err| CliError::UnexpectedError(err.to_string()));
-
+        let result = task::spawn_blocking(move || {
+            move_spec_test::run_spec_test(&spec_test_options.unwrap_or_default(), &config, &path)
+        })
+            .await
+            .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
         match result {
             Ok(_) => Ok("Success"),
-            Err(e) => Err(CliError::MoveSpecTestError(format!("{:#}", e))),
+            Err(e) => Err(CliError::MoveProverError(format!("{:#}", e))),
         }
     }
 }

--- a/third_party/move/tools/move-cli/src/base/mutate.rs
+++ b/third_party/move/tools/move-cli/src/base/mutate.rs
@@ -22,6 +22,6 @@ impl Mutate {
 
         let options = options.unwrap_or_default();
 
-        move_mutator::run_move_mutator(options, config, path)
+        move_mutator::run_move_mutator(options, &config, &path)
     }
 }

--- a/third_party/move/tools/move-cli/src/base/mutate.rs
+++ b/third_party/move/tools/move-cli/src/base/mutate.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 pub struct Mutate {
     /// Any options passed to the move-mutator
     #[clap(flatten)]
-    pub options: Option<move_mutator::cli::Options>,
+    pub options: Option<move_mutator::cli::CLIOptions>,
 }
 
 impl Mutate {

--- a/third_party/move/tools/move-cli/src/base/spec_test.rs
+++ b/third_party/move/tools/move-cli/src/base/spec_test.rs
@@ -24,6 +24,6 @@ impl SpecTest {
 
         let options = options.unwrap_or_default();
 
-        move_spec_test::run_spec_test(options, config, rerooted_path)
+        move_spec_test::run_spec_test(&options, &config, &rerooted_path)
     }
 }

--- a/third_party/move/tools/move-cli/src/base/spec_test.rs
+++ b/third_party/move/tools/move-cli/src/base/spec_test.rs
@@ -9,7 +9,7 @@ use crate::base::reroot_path;
 pub struct SpecTest {
     /// Any options passed to the move-spec-test
     #[clap(flatten)]
-    pub options: Option<move_spec_test::cli::Options>,
+    pub options: Option<move_spec_test::cli::CLIOptions>,
 }
 
 impl SpecTest {

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -30,6 +30,12 @@ or
 
 The output will be generated under the `mutants_output` (or any other selected) directory.
 
+Mutator tool respects `RUST_LOG` variable, and it will print out as much information as the variable allows. To see all the logs run:
+```bash
+RUST_LOG=trace ./target/debug/move mutate -m third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
+```
+There is possibility to enable logging only for the specific modules. Please refer to the [env_logger](https://docs.rs/env_logger/latest/env_logger/) documentation for more details.
+
 To check possible options run:
 ```bash
 ./target/debug/move mutate --help

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -160,6 +160,19 @@ Sample configuration file:
 }
 ```
 
+```toml
+[project]
+move_sources = ["/path/to/move/source"]
+[mutation]
+operators = ["operator1", "operator2"]
+categories = ["category1", "category2"]
+[[individual]]
+file = "/path/to/file"
+verify_mutants = true
+include_functions = ["function1", "function2"]
+exclude_functions = ["function3", "function4"]
+```
+
 ### Cross layer
 
 The layer is used to provide a common function set to other layers. None of their functions is exposed externally. Its crucial components are:

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -7,7 +7,7 @@ pub const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
 /// Command line options for mutator
 #[derive(Parser, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct Options {
+pub struct CLIOptions {
     /// The paths to the Move sources.
     #[clap(long, short, value_parser)]
     pub move_sources: Vec<PathBuf>,
@@ -37,7 +37,7 @@ pub struct Options {
     pub configuration_file: Option<PathBuf>,
 }
 
-impl Default for Options {
+impl Default for CLIOptions {
     // We need to implement default just because we need to specify the default value for out_mutant_dir.
     // Otherwise, out_mutant_dir would be empty. This is special case, when user won't specify any Options
     // (so the default value would be used), but define package_path (which is passed using other mechanism).

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -26,9 +26,12 @@ pub struct Options {
     /// Indicates if the output files should be overwritten.
     #[clap(long, short)]
     pub no_overwrite: Option<bool>,
-    /// Name of the filter to use for down sampling.
-    #[clap(long)]
+    /// Name of the filter to use for downsampling. Downsampling reduces the amount of mutants to the desired amount.
+    #[clap(long, hide = true)]
     pub downsample_filter: Option<String>,
+    /// Maximum number of mutants to be generated. If not specified, downsampling will be disabled. Currently only random filter is supported (mutants are removed randomly).
+    #[clap(long)]
+    pub downsample_num: Option<u64>,
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
@@ -47,6 +50,7 @@ impl Default for Options {
             verify_mutants: true,
             no_overwrite: None,
             downsample_filter: None,
+            downsample_num: None,
             configuration_file: None,
         }
     }

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::*;
+use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -47,7 +47,7 @@ pub fn generate_ast(
         .project
         .move_sources
         .iter()
-        .map(|p| p.to_str().expect("Source path contains invalid characters"))
+        .map(|p| p.to_str().expect("source path contains invalid characters"))
         .collect::<Vec<_>>();
 
     // If -m option is specified we should use only `move_sources`. However, if `move_sources` is empty
@@ -91,7 +91,7 @@ pub fn generate_ast(
     .set_interface_files_dir(
         interface_files_dir
             .to_str()
-            .expect("Output path contains invalid characters.")
+            .expect("output path contains invalid characters")
             .to_string(),
     )
     .run::<PASS_PARSER>()?;

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -18,7 +18,7 @@ pub struct Configuration {
     pub project_path: Option<PathBuf>,
     /// Configuration for the mutation operators (project-wide).
     pub mutation: Option<MutationConfig>,
-    /// Configuration for the individual files. (optional)
+    /// Configuration for the individual files. (optional).
     pub individual: Option<Vec<FileConfiguration>>,
 }
 
@@ -82,7 +82,7 @@ pub struct MutationConfig {
 pub struct FileConfiguration {
     /// The path to the Move source.
     pub file: PathBuf,
-    /// Indicates if the mutants should be verified
+    /// Indicates if the mutants should be verified.
     pub verify_mutants: Option<bool>,
     /// Names of the mutation operators to use. If not provided, all operators will be used.
     pub mutation_operators: Option<MutationConfig>,
@@ -191,7 +191,10 @@ mod tests {
             config.project.exclude_files.unwrap(),
             vec![Path::new("/path/to/exclude/file")]
         );
-        assert_eq!(config.project.out_mutant_dir, Some(PathBuf::from("/path/to/output")));
+        assert_eq!(
+            config.project.out_mutant_dir,
+            Some(PathBuf::from("/path/to/output"))
+        );
         assert_eq!(config.project.verify_mutants, true);
         assert_eq!(config.project.no_overwrite.unwrap(), false);
         assert_eq!(config.project.downsample_filter.unwrap(), "filter");

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -114,6 +114,7 @@ mod tests {
         "#;
         fs::write("test.toml", toml_content).unwrap();
         let config = Configuration::from_toml_file(Path::new("test.toml")).unwrap();
+        fs::remove_file("test.toml").unwrap();
         assert_eq!(
             config.project.move_sources,
             vec![Path::new("/path/to/move/source")]
@@ -122,7 +123,6 @@ mod tests {
             config.mutation.unwrap().operators,
             vec!["operator1", "operator2"]
         );
-        fs::remove_file("test.toml").unwrap();
     }
 
     #[test]
@@ -137,10 +137,10 @@ mod tests {
             [project]
             move_sources = "/path/to/move/source"
         "#;
-        fs::write("test.toml", toml_content).unwrap();
-        let result = Configuration::from_toml_file(Path::new("test.toml"));
+        fs::write("test_invalid.toml", toml_content).unwrap();
+        let result = Configuration::from_toml_file(Path::new("test_invalid.toml"));
+        fs::remove_file("test_invalid.toml").unwrap();
         assert!(result.is_err());
-        fs::remove_file("test.toml").unwrap();
     }
 
     #[test]
@@ -178,6 +178,7 @@ mod tests {
         "#;
         fs::write("test.json", json_content).unwrap();
         let config = Configuration::from_json_file(Path::new("test.json")).unwrap();
+        fs::remove_file("test.json").unwrap();
         assert_eq!(
             config.project.move_sources,
             vec![Path::new("/path/to/move/source")]
@@ -203,7 +204,6 @@ mod tests {
             config.mutation.unwrap().operators,
             vec!["operator1", "operator2"]
         );
-        fs::remove_file("test.json").unwrap();
     }
 
     #[test]
@@ -221,10 +221,10 @@ mod tests {
                 }
             }
         "#;
-        fs::write("test.json", json_content).unwrap();
-        let result = Configuration::from_json_file(Path::new("test.json"));
+        fs::write("test_invalid.json", json_content).unwrap();
+        let result = Configuration::from_json_file(Path::new("test_invalid.json"));
+        fs::remove_file("test_invalid.json").unwrap();
         assert!(result.is_err());
-        fs::remove_file("test.json").unwrap();
     }
 
     #[test]
@@ -241,39 +241,6 @@ mod tests {
             Configuration::get_file_type(Path::new("test.toml")).unwrap(),
             FileType::TOML
         );
-    }
-
-    #[test]
-    fn configuration_from_file_loads_json_correctly() {
-        let json_content = r#"
-            {
-                "project": {
-                    "move_sources": ["/path/to/move/source"]
-                }
-            }
-        "#;
-        fs::write("test.json", json_content).unwrap();
-        let config = Configuration::from_file(Path::new("test.json")).unwrap();
-        assert_eq!(
-            config.project.move_sources,
-            vec![Path::new("/path/to/move/source")]
-        );
-        fs::remove_file("test.json").unwrap();
-    }
-
-    #[test]
-    fn configuration_from_file_loads_toml_correctly() {
-        let toml_content = r#"
-            [project]
-            move_sources = ["/path/to/move/source"]
-        "#;
-        fs::write("test.toml", toml_content).unwrap();
-        let config = Configuration::from_file(Path::new("test.toml")).unwrap();
-        assert_eq!(
-            config.project.move_sources,
-            vec![Path::new("/path/to/move/source")]
-        );
-        fs::remove_file("test.toml").unwrap();
     }
 
     #[test]

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -1,4 +1,4 @@
-use crate::cli::Options;
+use crate::cli::CLIOptions;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -13,7 +13,7 @@ pub enum FileType {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Configuration {
     /// Main project options. It's the same as the CLI options.
-    pub project: Options,
+    pub project: CLIOptions,
     /// Path to the project.
     pub project_path: Option<PathBuf>,
     /// Configuration for the mutation operators (project-wide).
@@ -25,7 +25,7 @@ pub struct Configuration {
 impl Configuration {
     /// Creates a new configuration using command line options.
     #[must_use]
-    pub fn new(project: Options, project_path: Option<PathBuf>) -> Self {
+    pub fn new(project: CLIOptions, project_path: Option<PathBuf>) -> Self {
         Self {
             project,
             project_path,

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -24,6 +24,7 @@ pub struct Configuration {
 
 impl Configuration {
     /// Creates a new configuration using command line options.
+    #[must_use]
     pub fn new(project: Options, project_path: Option<PathBuf>) -> Self {
         Self {
             project,
@@ -189,7 +190,7 @@ mod tests {
             config.project.exclude_files.unwrap(),
             vec![Path::new("/path/to/exclude/file")]
         );
-        assert_eq!(config.project.out_mutant_dir, Path::new("/path/to/output"));
+        assert_eq!(config.project.out_mutant_dir, Some(PathBuf::from("/path/to/output")));
         assert_eq!(config.project.verify_mutants, true);
         assert_eq!(config.project.no_overwrite.unwrap(), false);
         assert_eq!(config.project.downsample_filter.unwrap(), "filter");

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -47,8 +47,7 @@ pub fn run_move_mutator(
     let _ = pretty_env_logger::try_init();
 
     info!(
-        "Executed move-mutator with the following options: {:?} \n config: {:?} \n package path: {:?}",
-        options, config, package_path
+        "Executed move-mutator with the following options: {options:?} \n config: {config:?} \n package path: {package_path:?}"
     );
 
     // Load configuration from file or create a new one.
@@ -84,8 +83,11 @@ pub fn run_move_mutator(
             }
         }
 
-        let mut i = 0;
-        for mutant in mutants.iter().filter(|m| m.get_file_hash() == hash) {
+        for (i, mutant) in mutants
+            .iter()
+            .filter(|m| m.get_file_hash() == hash)
+            .enumerate()
+        {
             let mutated_sources = mutant.apply(&source);
             for mutated in mutated_sources {
                 if mutator_configuration.project.verify_mutants {
@@ -94,14 +96,13 @@ pub fn run_move_mutator(
                     // In case the mutant is not a valid Move file, skip the mutant (do not save it).
                     if res.is_err() {
                         warn!(
-                            "Mutant {} is not valid and will not be generated. Error: {:?}",
-                            mutant, res
+                            "Mutant {mutant} is not valid and will not be generated. Error: {res:?}"
                         );
                         continue;
                     }
                 }
 
-                let mutant_path = output::setup_mutant_path(&output_dir, path, i)?;
+                let mutant_path = output::setup_mutant_path(&output_dir, path, i as u64)?;
                 fs::write(&mutant_path, &mutated.mutated_source)?;
 
                 info!("{} written to {}", mutant, mutant_path.display());
@@ -115,7 +116,6 @@ pub fn run_move_mutator(
 
                 entry.add_modification(mutated.mutation);
                 report.add_entry(entry);
-                i += 1;
             }
         }
     }

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 ///
 /// * `anyhow::Result<()>` - Returns `Ok(())` if the mutation process completes successfully, or an error if any error occurs.
 pub fn run_move_mutator(
-    options: cli::Options,
+    options: cli::CLIOptions,
     config: &BuildConfig,
     package_path: &PathBuf,
 ) -> anyhow::Result<()> {

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -1,16 +1,15 @@
-use move_compiler::parser;
-use move_compiler::parser::ast::{Exp, FunctionBody_, SequenceItem_};
+use move_compiler::parser::ast;
+use move_compiler::parser::ast::{
+    Definition::{Address, Module, Script},
+    Exp, FunctionBody_, ModuleMember, SequenceItem_,
+};
 
 use crate::mutant::Mutant;
 use crate::operator::MutationOperator;
-use move_compiler::parser::ast::{
-    Definition::{Address, Module, Script},
-    ModuleMember,
-};
 
 /// Traverses the AST, identifies places where mutation operators can be applied
 /// and returns a list of mutants.
-pub fn mutate(ast: parser::ast::Program) -> anyhow::Result<Vec<Mutant>> {
+pub fn mutate(ast: ast::Program) -> anyhow::Result<Vec<Mutant>> {
     trace!("Starting mutation process");
     let mutants = ast
         .source_definitions
@@ -34,7 +33,7 @@ pub fn mutate(ast: parser::ast::Program) -> anyhow::Result<Vec<Mutant>> {
 
 /// Traverses a single module and returns a list of mutants.
 /// Checks all the functions and constants defined in the module.
-fn traverse_module(module: parser::ast::ModuleDefinition) -> anyhow::Result<Vec<Mutant>> {
+fn traverse_module(module: ast::ModuleDefinition) -> anyhow::Result<Vec<Mutant>> {
     trace!("Traversing module {}", module.name);
     let mutants = module
         .members
@@ -59,7 +58,7 @@ fn traverse_module(module: parser::ast::ModuleDefinition) -> anyhow::Result<Vec<
 
 /// Traverses a single function and returns a list of mutants.
 /// Checks the body of the function by traversing all the sequences.
-fn traverse_function(function: parser::ast::Function) -> anyhow::Result<Vec<Mutant>> {
+fn traverse_function(function: ast::Function) -> anyhow::Result<Vec<Mutant>> {
     trace!("Traversing function {}", function.name);
     match function.body.value {
         FunctionBody_::Defined(elem) => traverse_sequence(elem),
@@ -69,9 +68,9 @@ fn traverse_function(function: parser::ast::Function) -> anyhow::Result<Vec<Muta
 
 /// Traverses a sequence and returns a list of mutants.
 /// Checks all the sequence items by calling `traverse_sequence_item` on them. Sequence can also contain
-/// return expression which needs to be also examined if it can be mutated..
-fn traverse_sequence(elem: parser::ast::Sequence) -> anyhow::Result<Vec<Mutant>> {
-    trace!("Traversing sequence {:?}", elem);
+/// return expression which needs to be also examined if it can be mutated.
+fn traverse_sequence(elem: ast::Sequence) -> anyhow::Result<Vec<Mutant>> {
+    trace!("Traversing sequence {elem:?}");
     let (_, seq, _, exp) = elem;
     let mut mutants = seq
         .into_iter()
@@ -79,7 +78,7 @@ fn traverse_sequence(elem: parser::ast::Sequence) -> anyhow::Result<Vec<Mutant>>
         .collect::<Result<Vec<_>, _>>()?
         .concat();
 
-    // exp represents the return expression so we need to remember to parse it
+    // exp represents the return expression so we need to remember to parse it.
     if let Some(exp) = *exp {
         mutants.extend(parse_expression_and_find_mutants(exp)?);
     }
@@ -90,7 +89,7 @@ fn traverse_sequence(elem: parser::ast::Sequence) -> anyhow::Result<Vec<Mutant>>
 
 /// Traverses a single sequence item and returns a list of mutants.
 /// Checks if binds or sequence items contain expressions that can be mutated by calling appropriate function on them..
-fn traverse_sequence_item(seq_item: parser::ast::SequenceItem) -> anyhow::Result<Vec<Mutant>> {
+fn traverse_sequence_item(seq_item: ast::SequenceItem) -> anyhow::Result<Vec<Mutant>> {
     trace!("Traversing sequence item {:?}", seq_item);
     match seq_item.value {
         SequenceItem_::Bind(_, _, exp) | SequenceItem_::Seq(exp) => {
@@ -101,8 +100,8 @@ fn traverse_sequence_item(seq_item: parser::ast::SequenceItem) -> anyhow::Result
 }
 
 /// Helper function that parses a list of expressions and returns a list of mutants.
-fn parse_expressions(exp: Vec<parser::ast::Exp>) -> anyhow::Result<Vec<Mutant>> {
-    trace!("Parsing expressions {:?}", exp);
+fn parse_expressions(exp: Vec<Exp>) -> anyhow::Result<Vec<Mutant>> {
+    trace!("Parsing expressions {exp:?}");
     Ok(exp
         .into_iter()
         .map(parse_expression_and_find_mutants)
@@ -114,48 +113,48 @@ fn parse_expressions(exp: Vec<parser::ast::Exp>) -> anyhow::Result<Vec<Mutant>> 
 /// can be applied to it.
 /// In case if the expression contains another expressions, it calls itself recursively.
 /// When Move language is extended with new expressions, this function needs to be updated to support them.
-fn parse_expression_and_find_mutants(exp: parser::ast::Exp) -> anyhow::Result<Vec<Mutant>> {
-    trace!("Parsing expression {:?}", exp);
+fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
+    trace!("Parsing expression {exp:?}");
     match exp.value {
-        parser::ast::Exp_::BinopExp(left, binop, right) => {
+        ast::Exp_::BinopExp(left, binop, right) => {
             // Parse left and right side of the operator as they are expressions and may contain
-            // another things to mutate
+            // another things to mutate.
             let mut mutants = parse_expression_and_find_mutants(*left)?;
             mutants.extend(parse_expression_and_find_mutants(*right)?);
 
-            // Add the mutation operator to the list of mutants
+            // Add the mutation operator to the list of mutants.
             mutants.push(Mutant::new(MutationOperator::BinaryOperator(binop)));
 
-            trace!("Found possible mutation in BinaryExp {:?}", binop);
+            trace!("Found possible mutation in BinaryExp {binop:?}");
 
             Ok(mutants)
         },
-        parser::ast::Exp_::UnaryExp(unop, exp) => {
-            // Parse the expression as it may contain another things to mutate
+        ast::Exp_::UnaryExp(unop, exp) => {
+            // Parse the expression as it may contain another things to mutate.
             let mut mutants = parse_expression_and_find_mutants(*exp)?;
 
-            // Add the mutation operator to the list of mutants
+            // Add the mutation operator to the list of mutants.
             mutants.push(Mutant::new(MutationOperator::UnaryOperator(unop)));
 
-            trace!("Found possible mutation in UnaryExp {:?}", unop);
+            trace!("Found possible mutation in UnaryExp {unop:?}");
 
             Ok(mutants)
         },
-        parser::ast::Exp_::Assign(exp1, exp2) | parser::ast::Exp_::While(exp1, exp2) => {
+        ast::Exp_::Assign(exp1, exp2) | ast::Exp_::While(exp1, exp2) => {
             let mut mutants = parse_expression_and_find_mutants(*exp1)?;
             mutants.extend(parse_expression_and_find_mutants(*exp2)?);
             Ok(mutants)
         },
-        parser::ast::Exp_::Block(seq) => traverse_sequence(seq),
-        parser::ast::Exp_::Pack(_, _, exps) => {
+        ast::Exp_::Block(seq) => traverse_sequence(seq),
+        ast::Exp_::Pack(_, _, exps) => {
             let exps = exps.into_iter().map(|(_, exp)| exp).collect::<Vec<Exp>>();
             parse_expressions(exps)
         },
-        parser::ast::Exp_::Call(_, _, _, exps) | parser::ast::Exp_::Vector(_, _, exps) => {
+        ast::Exp_::Call(_, _, _, exps) | ast::Exp_::Vector(_, _, exps) => {
             parse_expressions(exps.value)
         },
-        parser::ast::Exp_::ExpList(exps) => parse_expressions(exps),
-        parser::ast::Exp_::IfElse(exp1, exp2, exp3) => {
+        ast::Exp_::ExpList(exps) => parse_expressions(exps),
+        ast::Exp_::IfElse(exp1, exp2, exp3) => {
             let mut mutants = parse_expression_and_find_mutants(*exp1)?;
             mutants.extend(parse_expression_and_find_mutants(*exp2)?);
             if let Some(exp3) = exp3 {
@@ -163,7 +162,7 @@ fn parse_expression_and_find_mutants(exp: parser::ast::Exp) -> anyhow::Result<Ve
             }
             Ok(mutants)
         },
-        parser::ast::Exp_::Quant(_, _, vexp, lexp, exp) => {
+        ast::Exp_::Quant(_, _, vexp, lexp, exp) => {
             let mut mutants = vec![];
             for exp in vexp {
                 let muts = parse_expressions(exp)?;
@@ -175,25 +174,25 @@ fn parse_expression_and_find_mutants(exp: parser::ast::Exp) -> anyhow::Result<Ve
             mutants.extend(parse_expression_and_find_mutants(*exp)?);
             Ok(mutants)
         },
-        parser::ast::Exp_::Abort(exp)
-        | parser::ast::Exp_::Annotate(exp, _)
-        | parser::ast::Exp_::Borrow(_, exp)
-        | parser::ast::Exp_::Cast(exp, _)
-        | parser::ast::Exp_::Dereference(exp)
-        | parser::ast::Exp_::Dot(exp, _)
-        | parser::ast::Exp_::Loop(exp)
-        | parser::ast::Exp_::Lambda(_, exp)
-        | parser::ast::Exp_::Return(Some(exp)) => parse_expression_and_find_mutants(*exp),
-        parser::ast::Exp_::Value(_)
-        | parser::ast::Exp_::Move(_)
-        | parser::ast::Exp_::Copy(_)
-        | parser::ast::Exp_::Name(_, _)
-        | parser::ast::Exp_::Unit
-        | parser::ast::Exp_::Break
-        | parser::ast::Exp_::Continue
-        | parser::ast::Exp_::Spec(_)
-        | parser::ast::Exp_::Index(_, _)
-        | parser::ast::Exp_::UnresolvedError
-        | parser::ast::Exp_::Return(None) => Ok(vec![]),
+        ast::Exp_::Abort(exp)
+        | ast::Exp_::Annotate(exp, _)
+        | ast::Exp_::Borrow(_, exp)
+        | ast::Exp_::Cast(exp, _)
+        | ast::Exp_::Dereference(exp)
+        | ast::Exp_::Dot(exp, _)
+        | ast::Exp_::Loop(exp)
+        | ast::Exp_::Lambda(_, exp)
+        | ast::Exp_::Return(Some(exp)) => parse_expression_and_find_mutants(*exp),
+        ast::Exp_::Value(_)
+        | ast::Exp_::Move(_)
+        | ast::Exp_::Copy(_)
+        | ast::Exp_::Name(_, _)
+        | ast::Exp_::Unit
+        | ast::Exp_::Break
+        | ast::Exp_::Continue
+        | ast::Exp_::Spec(_)
+        | ast::Exp_::Index(_, _)
+        | ast::Exp_::UnresolvedError
+        | ast::Exp_::Return(None) => Ok(vec![]),
     }
 }

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -63,12 +63,12 @@ fn traverse_function(function: parser::ast::Function) -> anyhow::Result<Vec<Muta
     trace!("Traversing function {}", function.name);
     match function.body.value {
         FunctionBody_::Defined(elem) => traverse_sequence(elem),
-        _ => Ok(vec![]),
+        FunctionBody_::Native => Ok(vec![]),
     }
 }
 
 /// Traverses a sequence and returns a list of mutants.
-/// Checks all the sequence items by calling traverse_sequence_item on them. Sequence can also contain
+/// Checks all the sequence items by calling `traverse_sequence_item` on them. Sequence can also contain
 /// return expression which needs to be also examined if it can be mutated..
 fn traverse_sequence(elem: parser::ast::Sequence) -> anyhow::Result<Vec<Mutant>> {
     trace!("Traversing sequence {:?}", elem);
@@ -175,7 +175,6 @@ fn parse_expression_and_find_mutants(exp: parser::ast::Exp) -> anyhow::Result<Ve
             mutants.extend(parse_expression_and_find_mutants(*exp)?);
             Ok(mutants)
         },
-        parser::ast::Exp_::Return(Some(exp)) => parse_expression_and_find_mutants(*exp),
         parser::ast::Exp_::Abort(exp)
         | parser::ast::Exp_::Annotate(exp, _)
         | parser::ast::Exp_::Borrow(_, exp)
@@ -183,7 +182,8 @@ fn parse_expression_and_find_mutants(exp: parser::ast::Exp) -> anyhow::Result<Ve
         | parser::ast::Exp_::Dereference(exp)
         | parser::ast::Exp_::Dot(exp, _)
         | parser::ast::Exp_::Loop(exp)
-        | parser::ast::Exp_::Lambda(_, exp) => parse_expression_and_find_mutants(*exp),
+        | parser::ast::Exp_::Lambda(_, exp)
+        | parser::ast::Exp_::Return(Some(exp)) => parse_expression_and_find_mutants(*exp),
         parser::ast::Exp_::Value(_)
         | parser::ast::Exp_::Move(_)
         | parser::ast::Exp_::Copy(_)

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -40,7 +40,7 @@ impl MutationOperator {
     ///
     /// * `Vec<MutantInfo>` - A vector of `MutantInfo` instances representing the mutated source code.
     pub fn apply(&self, source: &str) -> Vec<MutantInfo> {
-        debug!("Applying mutation operator: {}", self);
+        debug!("Applying mutation operator: {self}");
 
         match self {
             MutationOperator::BinaryOperator(bin_op) => {
@@ -85,7 +85,7 @@ impl MutationOperator {
                 let end = unary_op.loc.end() as usize;
                 let cur_op = &source[start..end];
 
-                // For unary operator mutations, we only need to replace the operator with a space (to ensure the same file length)
+                // For unary operator mutations, we only need to replace the operator with a space (to ensure the same file length).
                 vec![" "]
                     .into_iter()
                     .map(|op| {

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -44,13 +44,10 @@ pub(crate) fn setup_mutant_path(
 
     let file_path_canonicalized = file_path.canonicalize()?;
 
-    // Try to find package root for the file. If the file is not inside any package, assume that it is a single file
+    // Try to find package root for the file. If the file is not inside any package, assume that it is a single file.
     let root = SourcePackageLayout::try_find_root(&file_path_canonicalized);
     let root_path = if root.is_err() {
-        debug!(
-            "No package root for {:?}. Assuming mutating a single file.",
-            file_path_canonicalized
-        );
+        debug!("No package root for {file_path_canonicalized:?}. Assuming mutating a single file.");
         file_path_canonicalized.clone()
     } else {
         // In case of file is inside the package it must follow the Move structure. So we can assume that
@@ -58,7 +55,7 @@ pub(crate) fn setup_mutant_path(
         root?.join("sources")
     };
 
-    // Stripping whole prefix before file to get it relative path inside the package
+    // Stripping whole prefix before file to get it relative path inside the package.
     let relative_path = file_path_canonicalized.strip_prefix(&root_path)?;
 
     // Construct the directory structure for that specified file in the output directory. If file was inside the package,
@@ -69,18 +66,16 @@ pub(crate) fn setup_mutant_path(
     if let Err(e) = fs::create_dir_all(&output_struct) {
         if e.kind() != std::io::ErrorKind::AlreadyExists {
             return Err(anyhow::anyhow!(
-                "Cannot create directory structure for {:?} in {:?}",
-                file_path,
-                output_dir
+                "Cannot create directory structure for {file_path:?} in {output_dir:?}"
             ));
         }
     }
 
     let filename = file_path
         .file_stem()
-        .ok_or(anyhow::anyhow!("Cannot get file stem of {:?}", file_path))?;
+        .ok_or(anyhow::anyhow!("Cannot get file stem of {file_path:?}"))?;
 
-    // Deal with the file as OsString to avoid problems with non-UTF8 characters
+    // Deal with the file as OsString to avoid problems with non-UTF8 characters.
     let mut filename = filename.to_os_string();
     filename.push(OsString::from(format!("_{index}.move")));
 
@@ -103,9 +98,9 @@ pub(crate) fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow:
         .out_mutant_dir
         .clone()
         .unwrap_or(PathBuf::from(cli::DEFAULT_OUTPUT_DIR));
-    trace!("Trying to set up output directory to: {:?}", output_dir);
+    trace!("Trying to set up output directory to: {output_dir:?}");
 
-    // Check if output directory exists and if it should be overwritten
+    // Check if output directory exists and if it should be overwritten.
     if output_dir.exists() && mutator_configuration.project.no_overwrite.unwrap_or(false) {
         return Err(anyhow::anyhow!(
             "Output directory already exists. Use --no-overwrite=false to overwrite."
@@ -115,7 +110,7 @@ pub(crate) fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow:
     let _ = fs::remove_dir_all(&output_dir);
     fs::create_dir(&output_dir)?;
 
-    debug!("Output directory set to: {:?}", output_dir);
+    debug!("Output directory set to: {output_dir:?}");
 
     Ok(output_dir)
 }
@@ -168,7 +163,10 @@ mod tests {
         fs::remove_file(filename).unwrap();
         fs::remove_dir_all(output_dir).unwrap();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), PathBuf::from("mutants_output_correct/test_correct_1.move"));
+        assert_eq!(
+            result.unwrap(),
+            PathBuf::from("mutants_output_correct/test_correct_1.move")
+        );
     }
 
     #[test]

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -194,7 +194,7 @@ mod tests {
     fn setup_output_dir_creates_directory_if_not_exists() {
         let temp_dir = tempdir().unwrap();
         let output_dir = temp_dir.path().join("output");
-        let options = cli::Options {
+        let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
             no_overwrite: Some(false),
             ..Default::default()
@@ -209,7 +209,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let output_dir = temp_dir.path().join("output");
         fs::create_dir(&output_dir).unwrap();
-        let options = cli::Options {
+        let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
             no_overwrite: Some(false),
             ..Default::default()
@@ -224,7 +224,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let output_dir = temp_dir.path().join("output");
         fs::create_dir(&output_dir).unwrap();
-        let options = cli::Options {
+        let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
             no_overwrite: Some(true),
             ..Default::default()

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -12,15 +12,15 @@ use std::path::{Path, PathBuf};
 /// according to its relative path inside the package. If the file is not inside any package,
 /// it creates the directory structure in the output directory.
 /// Example:
-/// The file to be mutated is located in "/a/b/c/sources/X/Y/file.move" (file_path).
+/// The file to be mutated is located in "/a/b/c/sources/X/Y/file.move" (`file_path`).
 /// This function constructs the following output path for file.move:
-/// "output_dir/X/Y/file_index.move"
+/// "`output_dir/X/Y/file_index.move`"
 /// It finds the package root for the file, which is "/a/b/c", then it append the relative path to the output directory.
 ///
 /// If the file is not inside any package, it creates the directory structure in the output directory like:
-/// The file to be mutated is located in "/a/b/c/file.move" (file_path).
+/// The file to be mutated is located in "/a/b/c/file.move" (`file_path`).
 /// This function constructs the following output path for file.move:
-/// "output_dir/file_index.move"
+/// "`output_dir/file_index.move`"
 ///
 /// # Arguments
 ///
@@ -46,7 +46,7 @@ pub(crate) fn setup_mutant_path(
 
     // Try to find package root for the file. If the file is not inside any package, assume that it is a single file
     let root = SourcePackageLayout::try_find_root(&file_path_canonicalized);
-    let root_path = if let Err(_) = root {
+    let root_path = if root.is_err() {
         debug!(
             "No package root for {:?}. Assuming mutating a single file.",
             file_path_canonicalized
@@ -82,7 +82,7 @@ pub(crate) fn setup_mutant_path(
 
     // Deal with the file as OsString to avoid problems with non-UTF8 characters
     let mut filename = filename.to_os_string();
-    filename.push(OsString::from(format!("_{}.move", index)));
+    filename.push(OsString::from(format!("_{index}.move")));
 
     Ok(output_struct.join(filename))
 }

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -137,52 +137,55 @@ mod tests {
         let index = 1;
         let result = setup_mutant_path(output_dir, filename, index);
         fs::remove_file(filename).unwrap();
+        fs::remove_dir_all(output_dir).unwrap();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), PathBuf::from("mutants_output/💖_1.move"));
     }
 
     #[test]
     fn setup_mutant_path_handles_file_without_extension() {
-        let output_dir = Path::new("mutants_output");
+        let output_dir = Path::new("mutants_output_no_extension");
         let filename = Path::new("file1");
         fs::File::create(filename).unwrap();
         let index = 1;
         let result = setup_mutant_path(output_dir, filename, index);
         fs::remove_file(filename).unwrap();
+        fs::remove_dir_all(output_dir).unwrap();
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap(),
-            PathBuf::from("mutants_output/file1_1.move")
+            PathBuf::from("mutants_output_no_extension/file1_1.move")
         );
     }
 
     #[test]
     fn setup_mutant_path_creates_correct_path() {
-        let output_dir = Path::new("mutants_output");
-        let filename = Path::new("test");
+        let output_dir = Path::new("mutants_output_correct");
+        let filename = Path::new("test_correct");
         fs::File::create(filename).unwrap();
         let index = 1;
         let result = setup_mutant_path(output_dir, filename, index);
         fs::remove_file(filename).unwrap();
+        fs::remove_dir_all(output_dir).unwrap();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), PathBuf::from("mutants_output/test_1.move"));
+        assert_eq!(result.unwrap(), PathBuf::from("mutants_output_correct/test_correct_1.move"));
     }
 
     #[test]
     fn setup_mutant_path_handles_empty_output_dir() {
         let output_dir = Path::new("");
-        let filename = Path::new("test");
+        let filename = Path::new("test_empty");
         fs::File::create(filename).unwrap();
         let index = 1;
         let result = setup_mutant_path(output_dir, filename, index);
         fs::remove_file(filename).unwrap();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), PathBuf::from("test_1.move"));
+        assert_eq!(result.unwrap(), PathBuf::from("test_empty_1.move"));
     }
 
     #[test]
     fn setup_mutant_path_handles_empty_filename() {
-        let output_dir = Path::new("mutants_output");
+        let output_dir = Path::new("mutants_output_empty_filename");
         let filename = Path::new("");
         let index = 1;
         let result = setup_mutant_path(output_dir, filename, index);

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -13,6 +13,7 @@ pub struct Report {
 
 impl Report {
     /// Creates a new `Report` instance.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             mutants: Vec::new(),
@@ -74,6 +75,7 @@ impl Report {
     }
 
     /// Returns the vector of `MutationReport` instances.
+    #[must_use]
     pub fn get_mutants(&self) -> &Vec<MutationReport> {
         &self.mutants
     }
@@ -82,6 +84,12 @@ impl Report {
     #[cfg(test)]
     pub fn to_json(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(&self)
+    }
+}
+
+impl Default for Report {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -97,7 +105,10 @@ pub struct Range {
 
 impl Range {
     /// Creates a new `Range` instance.
+    ///
+    /// # Panics
     /// The start must be smaller or equal to the end.
+    #[must_use]
     pub fn new(start: usize, end: usize) -> Self {
         assert!(start <= end);
         Self { start, end }
@@ -121,6 +132,7 @@ pub struct Mutation {
 
 impl Mutation {
     /// Creates a new `Mutation` instance.
+    #[must_use]
     pub fn new(
         changed_place: Range,
         operator_name: String,
@@ -153,6 +165,7 @@ pub struct MutationReport {
 impl MutationReport {
     /// Creates a new `MutationReport` instance.
     /// Generates diff (patch) between the original and mutated source.
+    #[must_use]
     pub fn new(
         mutant_path: &Path,
         original_file: &Path,
@@ -175,11 +188,13 @@ impl MutationReport {
     }
 
     /// Return the mutant path.
+    #[must_use]
     pub fn mutant_path(&self) -> &PathBuf {
         &self.mutant_path
     }
 
     /// Return the original file path.
+    #[must_use]
     pub fn original_file_path(&self) -> &PathBuf {
         &self.original_file
     }

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -22,7 +22,7 @@ impl Report {
 
     /// Adds a new `MutationReport` to the report.
     pub fn add_entry(&mut self, entry: MutationReport) {
-        trace!("Adding a mutant to the report: {:?}", entry);
+        trace!("Adding a mutant to the report: {entry:?}");
         self.mutants.push(entry);
     }
 

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -56,7 +56,7 @@ pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover:
 
 /// This function checks if the mutator output path is provided in the configuration file.
 /// We don't need to check if the mutator output path is provided in the options as they were created
-/// from the spec-test options which does not allow to set it.
+/// from the spec-test options which does not allow setting it.
 #[must_use]
 pub fn check_mutator_output_path(options: &move_mutator::cli::Options) -> Option<PathBuf> {
     if let Some(conf) = &options.configuration_file {

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::*;
+use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -27,6 +27,7 @@ pub struct Options {
 }
 
 /// This function creates a mutator CLI options from the given spec-test options.
+#[must_use]
 pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
     move_mutator::cli::Options {
         move_sources: options.move_sources.clone(),
@@ -38,6 +39,9 @@ pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
 }
 
 /// This function generates a prover CLI options from the given spec-test options.
+///
+/// # Errors
+/// Errors are returned as `anyhow::Result`.
 pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover::cli::Options> {
     let prover_conf = if let Some(conf) = &options.prover_conf {
         move_prover::cli::Options::create_from_toml_file(conf.to_str().unwrap_or(""))?
@@ -52,7 +56,8 @@ pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover:
 
 /// This function checks if the mutator output path is provided in the configuration file.
 /// We don't need to check if the mutator output path is provided in the options as they were created
-/// from the spec-test options which does not allow to set it..
+/// from the spec-test options which does not allow to set it.
+#[must_use]
 pub fn check_mutator_output_path(options: &move_mutator::cli::Options) -> Option<PathBuf> {
     if let Some(conf) = &options.configuration_file {
         let c = move_mutator::configuration::Configuration::from_file(conf);

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 /// Command line options for specification test tool.
 #[derive(Parser, Default, Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct Options {
+pub struct CLIOptions {
     /// The paths to the Move sources.
     #[clap(long, short, value_parser)]
     pub move_sources: Vec<PathBuf>,
@@ -28,8 +28,8 @@ pub struct Options {
 
 /// This function creates a mutator CLI options from the given spec-test options.
 #[must_use]
-pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
-    move_mutator::cli::Options {
+pub fn create_mutator_options(options: &CLIOptions) -> move_mutator::cli::CLIOptions {
+    move_mutator::cli::CLIOptions {
         move_sources: options.move_sources.clone(),
         include_only_files: options.include_only_files.clone(),
         exclude_files: options.exclude_files.clone(),
@@ -42,7 +42,7 @@ pub fn create_mutator_options(options: &Options) -> move_mutator::cli::Options {
 ///
 /// # Errors
 /// Errors are returned as `anyhow::Result`.
-pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover::cli::Options> {
+pub fn generate_prover_options(options: &CLIOptions) -> anyhow::Result<move_prover::cli::Options> {
     let prover_conf = if let Some(conf) = &options.prover_conf {
         move_prover::cli::Options::create_from_toml_file(conf.to_str().unwrap_or(""))?
     } else if let Some(args) = &options.extra_prover_args {
@@ -58,7 +58,7 @@ pub fn generate_prover_options(options: &Options) -> anyhow::Result<move_prover:
 /// We don't need to check if the mutator output path is provided in the options as they were created
 /// from the spec-test options which does not allow setting it.
 #[must_use]
-pub fn check_mutator_output_path(options: &move_mutator::cli::Options) -> Option<PathBuf> {
+pub fn check_mutator_output_path(options: &move_mutator::cli::CLIOptions) -> Option<PathBuf> {
     if let Some(conf) = &options.configuration_file {
         let c = move_mutator::configuration::Configuration::from_file(conf);
         if let Ok(c) = c {

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -32,7 +32,7 @@ use std::path::PathBuf;
 ///
 /// * `anyhow::Result<()>` - The result of the spec test.
 pub fn run_spec_test(
-    options: &cli::Options,
+    options: &cli::CLIOptions,
     config: &BuildConfig,
     package_path: &PathBuf,
 ) -> anyhow::Result<()> {

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -45,7 +45,7 @@ pub fn run_spec_test(
     let mut mutator_conf = cli::create_mutator_options(options);
     let prover_conf = cli::generate_prover_options(options)?;
 
-    // Setup temporary directory structure
+    // Setup temporary directory structure.
     let outdir = tempfile::tempdir()?.into_path();
     let outdir_mutant = outdir.join("mutants");
     let outdir_original = outdir.join("base");
@@ -64,7 +64,7 @@ pub fn run_spec_test(
     let report =
         move_mutator::report::Report::load_from_json_file(&outdir_mutant.join("report.json"))?;
 
-    // Proving part
+    // Proving part.
     move_mutator::compiler::copy_dir_all(package_path, &outdir_original)?;
 
     let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
@@ -84,8 +84,11 @@ pub fn run_spec_test(
     for elem in report.get_mutants() {
         total_mutants += 1;
         let mutant_file = elem.mutant_path();
-        // Strip prefix to get the path relative to the package directory (or take that path if it's already relative)
-        let original_file = elem.original_file_path().strip_prefix(package_path).unwrap_or(&elem.original_file_path());
+        // Strip prefix to get the path relative to the package directory (or take that path if it's already relative).
+        let original_file = elem
+            .original_file_path()
+            .strip_prefix(package_path)
+            .unwrap_or(&elem.original_file_path());
         let outdir_prove = outdir.join("prove");
 
         let _ = fs::remove_dir_all(&outdir_prove);
@@ -99,15 +102,14 @@ pub fn run_spec_test(
 
         if let Err(res) = fs::copy(mutant_file, outdir_prove.join(original_file)) {
             return Err(anyhow!(
-                "Can't copy mutant file to the package directory: {:?}",
-                res
+                "Can't copy mutant file to the package directory: {res:?}"
             ));
         }
 
         let result = prove(config, &outdir_prove, &prover_conf, &mut error_writer);
 
         if let Err(e) = result {
-            trace!("Mutant killed! Prover failed with error: {}", e);
+            trace!("Mutant killed! Prover failed with error: {e}");
             killed_mutants += 1;
         } else {
             trace!("Mutant hasn't been killed!");

--- a/third_party/move/tools/move-spec-test/src/prover.rs
+++ b/third_party/move/tools/move-spec-test/src/prover.rs
@@ -29,12 +29,15 @@ pub(crate) fn prove<W: WriteColor>(
         },
     )?;
 
+    let mut prover_conf = prover_conf.clone();
+    prover_conf.output_path = package_path
+        .to_path_buf()
+        .join("output.bpl")
+        .to_str()
+        .unwrap_or("")
+        .to_string();
+
     let now = Instant::now();
 
-    move_prover::run_move_prover_with_model(
-        &model,
-        &mut error_writer,
-        prover_conf.clone(),
-        Some(now),
-    )
+    move_prover::run_move_prover_with_model(&model, &mut error_writer, prover_conf, Some(now))
 }


### PR DESCRIPTION
### Description

That's a technical PR which implements:
- milestone review remarks;
- comments and log messages cleanups;
- code shortenings and small fixes;
- test fixes to run with more than one thread;
- running Move Prover correctly when called from `aptos` command;
- clippy cleanups;
- minor refactoring like changing variable or struct names.


