### PR TITLE
[move-mutator] mutation operator refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,7 @@ dependencies = [
  "move-coverage",
  "move-disassembler",
  "move-ir-types",
- "move-mutator",
  "move-package",
- "move-spec-test",
  "move-symbol-pool",
  "move-unit-test",
  "move-vm-runtime",
@@ -6911,15 +6909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diffy"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
-dependencies = [
- "nu-ansi-term",
-]
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10368,11 +10357,9 @@ dependencies = [
  "move-errmapgen",
  "move-ir-types",
  "move-model",
- "move-mutator",
  "move-package",
  "move-prover",
  "move-resource-viewer",
- "move-spec-test",
  "move-stdlib",
  "move-symbol-pool",
  "move-table-extension",
@@ -10704,25 +10691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-mutator"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap 4.4.12",
- "diffy",
- "log",
- "move-command-line-common",
- "move-compiler",
- "move-ir-types",
- "move-package",
- "pretty_env_logger",
- "serde",
- "serde_json",
- "tempfile",
- "toml 0.5.11",
-]
-
-[[package]]
 name = "move-package"
 version = "0.1.0"
 dependencies = [
@@ -10889,25 +10857,6 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "serde",
-]
-
-[[package]]
-name = "move-spec-test"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap 4.4.12",
- "log",
- "move-command-line-common",
- "move-mutator",
- "move-package",
- "move-prover",
- "pretty_env_logger",
- "serde",
- "serde_json",
- "tabled",
- "tempfile",
- "termcolor",
 ]
 
 [[package]]
@@ -11809,17 +11758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "papergrid"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb"
-dependencies = [
- "bytecount",
- "fnv",
- "unicode-width",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12625,16 +12563,6 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi 0.5.1",
-]
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
 ]
 
 [[package]]
@@ -15100,30 +15028,6 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tabled"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e"
-dependencies = [
- "papergrid",
- "tabled_derive",
- "unicode-width",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2 1.0.75",
- "quote 1.0.35",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,9 @@ dependencies = [
  "move-coverage",
  "move-disassembler",
  "move-ir-types",
+ "move-mutator",
  "move-package",
+ "move-spec-test",
  "move-symbol-pool",
  "move-unit-test",
  "move-vm-runtime",
@@ -6909,6 +6911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "diffy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
+dependencies = [
+ "nu-ansi-term",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10357,9 +10368,11 @@ dependencies = [
  "move-errmapgen",
  "move-ir-types",
  "move-model",
+ "move-mutator",
  "move-package",
  "move-prover",
  "move-resource-viewer",
+ "move-spec-test",
  "move-stdlib",
  "move-symbol-pool",
  "move-table-extension",
@@ -10691,6 +10704,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-mutator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.4.12",
+ "diffy",
+ "log",
+ "move-command-line-common",
+ "move-compiler",
+ "move-ir-types",
+ "move-package",
+ "pretty_env_logger",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "move-package"
 version = "0.1.0"
 dependencies = [
@@ -10857,6 +10889,25 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "serde",
+]
+
+[[package]]
+name = "move-spec-test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.4.12",
+ "log",
+ "move-command-line-common",
+ "move-mutator",
+ "move-package",
+ "move-prover",
+ "pretty_env_logger",
+ "serde",
+ "serde_json",
+ "tabled",
+ "tempfile",
+ "termcolor",
 ]
 
 [[package]]
@@ -11758,6 +11809,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12563,6 +12625,16 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi 0.5.1",
+]
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger",
+ "log",
 ]
 
 [[package]]
@@ -15028,6 +15100,30 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tabled"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -267,15 +267,17 @@ The Move mutator tool is designed to be easily extensible. It's possible to add 
 
 To add a new mutation operator, you need to:
 1. Add a new mutation operator to the `MutationOperator` enum in the `operator.rs` file.
-2. Implement mutation logic in the `apply` function in the `operator.rs` file.
-3. Update AST traversal code in the `mutate.rs` file - add or modify a place in the AST where the mutation operator should be applied.
-4. Add a test for the new mutation operator.
+2. Add appropriate calls to the `MutationOperator` implementation in the `operator.rs` file.
+3. Create new file with the mutation operator implementation in the `operators` directory.
+4. Implement mutation logic in the `apply` and `get_file_hash` functions in the newly created file.
+5. Update AST traversal code in the `mutate.rs` file - add or modify a place in the AST where the mutation operator should be applied.
+6. Add a test for the new mutation operator.
 
 ### Adding a new mutation category
 
 Sometimes, it's helpful to group mutation operators into categories. For example, it's useful to group arithmetic operators together. It's possible to do it by adding a new mutation category.
 
-Categories exist only to group mutation operators. They are not used anywhere else. They reside in the `operator.rs` file inside the `apply` function. To add a new category, simply modify the existing operator, adding or excluding new groups based on the already present code (look at the `BinaryOperator`, `ops` vector).
+Categories exist only to group mutation operators. They are not used anywhere else. They reside in the file with mutation operator in `operators` directory, inside the `apply` function. To add a new category, simply modify the existing operator, adding or excluding new groups based on the already present code (look at the `BinaryOperator`, `ops` vector).
 
 
 

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -10,6 +10,7 @@ mod mutate;
 pub mod configuration;
 mod mutant;
 mod operator;
+mod operators;
 mod output;
 pub mod report;
 

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,4 +1,4 @@
-use crate::operator::{MutantInfo, MutationOperator};
+use crate::operator::{MutantInfo, MutationOperator, MutationOperatorTrait};
 use move_command_line_common::files::FileHash;
 use std::fmt;
 
@@ -40,14 +40,15 @@ mod tests {
     use move_command_line_common::files::FileHash;
     use move_compiler::parser::ast::{BinOp, BinOp_};
     use move_ir_types::location::Loc;
+    use crate::operators::binary::BinaryOperator;
 
     #[test]
     fn test_new() {
         let loc = Loc::new(FileHash::new(""), 0, 0);
-        let operator = MutationOperator::BinaryOperator(BinOp {
+        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(BinOp {
             value: BinOp_::Add,
             loc,
-        });
+        }));
         let mutant = Mutant::new(operator);
         assert_eq!(format!("{}", mutant), "Mutant: BinaryOperator(+, location: file hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, index start: 0, index stop: 0)");
     }
@@ -55,10 +56,10 @@ mod tests {
     #[test]
     fn test_get_file_hash() {
         let loc = Loc::new(FileHash::new(""), 0, 0);
-        let operator = MutationOperator::BinaryOperator(BinOp {
+        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(BinOp {
             value: BinOp_::Add,
             loc,
-        });
+        }));
         let mutant = Mutant::new(operator);
         assert_eq!(mutant.get_file_hash(), FileHash::new(""));
     }
@@ -66,10 +67,10 @@ mod tests {
     #[test]
     fn test_apply() {
         let loc = Loc::new(FileHash::new(""), 0, 1);
-        let operator = MutationOperator::BinaryOperator(BinOp {
+        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(BinOp {
             value: BinOp_::Add,
             loc,
-        });
+        }));
         let mutant = Mutant::new(operator);
         let source = "+";
         let expected = vec!["-", "*", "/", "%"];

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,4 +1,4 @@
-use crate::operator::{MutantInfo, MutationOperator, MutationOperatorTrait};
+use crate::operator::{MutantInfo, MutationOp, MutationOperator};
 use move_command_line_common::files::FileHash;
 use std::fmt;
 
@@ -6,12 +6,12 @@ use std::fmt;
 /// This represents mutant as a mutation operator.
 #[derive(Debug, Clone)]
 pub struct Mutant {
-    operator: MutationOperator,
+    operator: MutationOp,
 }
 
 impl Mutant {
     /// Creates a new mutant.
-    pub fn new(operator: MutationOperator) -> Self {
+    pub fn new(operator: MutationOp) -> Self {
         Self { operator }
     }
 
@@ -40,12 +40,12 @@ mod tests {
     use move_command_line_common::files::FileHash;
     use move_compiler::parser::ast::{BinOp, BinOp_};
     use move_ir_types::location::Loc;
-    use crate::operators::binary::BinaryOperator;
+    use crate::operators::binary::Binary;
 
     #[test]
     fn test_new() {
         let loc = Loc::new(FileHash::new(""), 0, 0);
-        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(BinOp {
+        let operator = MutationOp::BinaryOp(Binary::new(BinOp {
             value: BinOp_::Add,
             loc,
         }));
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn test_get_file_hash() {
         let loc = Loc::new(FileHash::new(""), 0, 0);
-        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(BinOp {
+        let operator = MutationOp::BinaryOp(Binary::new(BinOp {
             value: BinOp_::Add,
             loc,
         }));
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn test_apply() {
         let loc = Loc::new(FileHash::new(""), 0, 1);
-        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(BinOp {
+        let operator = MutationOp::BinaryOp(Binary::new(BinOp {
             value: BinOp_::Add,
             loc,
         }));

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -6,6 +6,8 @@ use move_compiler::parser::ast::{
 
 use crate::mutant::Mutant;
 use crate::operator::MutationOperator;
+use crate::operators::binary::BinaryOperator;
+use crate::operators::unary::UnaryOperator;
 
 /// Traverses the AST, identifies places where mutation operators can be applied
 /// and returns a list of mutants.
@@ -123,7 +125,9 @@ fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
             mutants.extend(parse_expression_and_find_mutants(*right)?);
 
             // Add the mutation operator to the list of mutants.
-            mutants.push(Mutant::new(MutationOperator::BinaryOperator(binop)));
+            mutants.push(Mutant::new(MutationOperator::BinaryOperator(
+                BinaryOperator::new(binop),
+            )));
 
             trace!("Found possible mutation in BinaryExp {binop:?}");
 
@@ -134,7 +138,9 @@ fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
             let mut mutants = parse_expression_and_find_mutants(*exp)?;
 
             // Add the mutation operator to the list of mutants.
-            mutants.push(Mutant::new(MutationOperator::UnaryOperator(unop)));
+            mutants.push(Mutant::new(MutationOperator::UnaryOperator(
+                UnaryOperator::new(unop),
+            )));
 
             trace!("Found possible mutation in UnaryExp {unop:?}");
 

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -5,9 +5,9 @@ use move_compiler::parser::ast::{
 };
 
 use crate::mutant::Mutant;
-use crate::operator::MutationOperator;
-use crate::operators::binary::BinaryOperator;
-use crate::operators::unary::UnaryOperator;
+use crate::operator::MutationOp;
+use crate::operators::binary::Binary;
+use crate::operators::unary::Unary;
 
 /// Traverses the AST, identifies places where mutation operators can be applied
 /// and returns a list of mutants.
@@ -125,8 +125,8 @@ fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
             mutants.extend(parse_expression_and_find_mutants(*right)?);
 
             // Add the mutation operator to the list of mutants.
-            mutants.push(Mutant::new(MutationOperator::BinaryOperator(
-                BinaryOperator::new(binop),
+            mutants.push(Mutant::new(MutationOp::BinaryOp(
+                Binary::new(binop),
             )));
 
             trace!("Found possible mutation in BinaryExp {binop:?}");
@@ -138,8 +138,8 @@ fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
             let mut mutants = parse_expression_and_find_mutants(*exp)?;
 
             // Add the mutation operator to the list of mutants.
-            mutants.push(Mutant::new(MutationOperator::UnaryOperator(
-                UnaryOperator::new(unop),
+            mutants.push(Mutant::new(MutationOp::UnaryOp(
+                Unary::new(unop),
             )));
 
             trace!("Found possible mutation in UnaryExp {unop:?}");

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,5 +1,5 @@
-use crate::operators::binary::BinaryOperator;
-use crate::operators::unary::UnaryOperator;
+use crate::operators::binary::Binary;
+use crate::operators::unary::Unary;
 use crate::report::Mutation;
 use move_command_line_common::files::FileHash;
 use std::fmt;
@@ -26,7 +26,7 @@ impl MutantInfo {
 /// Trait for mutation operators.
 /// Mutation operators are used to apply mutations to the source code. To keep adding new mutation operators simple,
 /// we use a trait that all mutation operators implement.
-pub trait MutationOperatorTrait {
+pub trait MutationOperator {
     /// Applies the mutation operator to the given source code.
     /// Returns differently mutated source code listings in a vector.
     ///
@@ -45,34 +45,34 @@ pub trait MutationOperatorTrait {
 
 /// The mutation operator to apply.
 #[derive(Debug, Copy, Clone)]
-pub enum MutationOperator {
-    BinaryOperator(BinaryOperator),
-    UnaryOperator(UnaryOperator),
+pub enum MutationOp {
+    BinaryOp(Binary),
+    UnaryOp(Unary),
 }
 
-impl MutationOperatorTrait for MutationOperator {
+impl MutationOperator for MutationOp {
     fn apply(&self, source: &str) -> Vec<MutantInfo> {
         debug!("Applying mutation operator: {self}");
 
         match self {
-            MutationOperator::BinaryOperator(bin_op) => bin_op.apply(source),
-            MutationOperator::UnaryOperator(unary_op) => unary_op.apply(source),
+            MutationOp::BinaryOp(bin_op) => bin_op.apply(source),
+            MutationOp::UnaryOp(unary_op) => unary_op.apply(source),
         }
     }
 
     fn get_file_hash(&self) -> FileHash {
         match self {
-            MutationOperator::BinaryOperator(bin_op) => bin_op.get_file_hash(),
-            MutationOperator::UnaryOperator(unary_op) => unary_op.get_file_hash(),
+            MutationOp::BinaryOp(bin_op) => bin_op.get_file_hash(),
+            MutationOp::UnaryOp(unary_op) => unary_op.get_file_hash(),
         }
     }
 }
 
-impl fmt::Display for MutationOperator {
+impl fmt::Display for MutationOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            MutationOperator::BinaryOperator(bin_op) => write!(f, "{}", bin_op),
-            MutationOperator::UnaryOperator(unary_op) => write!(f, "{}", unary_op),
+            MutationOp::BinaryOp(bin_op) => write!(f, "{}", bin_op),
+            MutationOp::UnaryOp(unary_op) => write!(f, "{}", unary_op),
         }
     }
 }
@@ -91,7 +91,7 @@ mod tests {
             value: BinOp_::Mul,
             loc,
         };
-        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(bin_op));
+        let operator = MutationOp::BinaryOp(Binary::new(bin_op));
         let source = "*";
         let expected = vec!["+", "-", "/", "%"];
         let result = operator.apply(source);
@@ -108,7 +108,7 @@ mod tests {
             value: UnaryOp_::Not,
             loc,
         };
-        let operator = MutationOperator::UnaryOperator(UnaryOperator::new(unary_op));
+        let operator = MutationOp::UnaryOp(Unary::new(unary_op));
         let source = "!";
         let expected = vec![" "];
         let result = operator.apply(source);
@@ -125,7 +125,7 @@ mod tests {
             value: BinOp_::Add,
             loc,
         };
-        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(bin_op));
+        let operator = MutationOp::BinaryOp(Binary::new(bin_op));
         assert_eq!(operator.get_file_hash(), FileHash::new(""));
     }
 }

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,7 +1,9 @@
-use crate::report::{Mutation, Range};
+use crate::operators::binary::BinaryOperator;
+use crate::operators::unary::UnaryOperator;
+use crate::report::Mutation;
 use move_command_line_common::files::FileHash;
-use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp};
 use std::fmt;
+use std::fmt::Debug;
 
 /// Mutation result that contains the mutated source code and the modification that was applied.
 pub struct MutantInfo {
@@ -21,14 +23,10 @@ impl MutantInfo {
     }
 }
 
-/// The mutation operator to apply.
-#[derive(Debug, Copy, Clone)]
-pub enum MutationOperator {
-    BinaryOperator(BinOp),
-    UnaryOperator(UnaryOp),
-}
-
-impl MutationOperator {
+/// Trait for mutation operators.
+/// Mutation operators are used to apply mutations to the source code. To keep adding new mutation operators simple,
+/// we use a trait that all mutation operators implement.
+pub trait MutationOperatorTrait {
     /// Applies the mutation operator to the given source code.
     /// Returns differently mutated source code listings in a vector.
     ///
@@ -39,78 +37,33 @@ impl MutationOperator {
     /// # Returns
     ///
     /// * `Vec<MutantInfo>` - A vector of `MutantInfo` instances representing the mutated source code.
-    pub fn apply(&self, source: &str) -> Vec<MutantInfo> {
+    fn apply(&self, source: &str) -> Vec<MutantInfo>;
+
+    /// Returns the file hash of the file that this mutation operator is in.
+    fn get_file_hash(&self) -> FileHash;
+}
+
+/// The mutation operator to apply.
+#[derive(Debug, Copy, Clone)]
+pub enum MutationOperator {
+    BinaryOperator(BinaryOperator),
+    UnaryOperator(UnaryOperator),
+}
+
+impl MutationOperatorTrait for MutationOperator {
+    fn apply(&self, source: &str) -> Vec<MutantInfo> {
         debug!("Applying mutation operator: {self}");
 
         match self {
-            MutationOperator::BinaryOperator(bin_op) => {
-                let start = bin_op.loc.start() as usize;
-                let end = bin_op.loc.end() as usize;
-                let cur_op = &source[start..end];
-
-                // Group of exchangeable binary operators - we only want to replace the operator with a different one
-                // within the same group.
-                let ops: Vec<&str> = match bin_op.value {
-                    BinOp_::Add | BinOp_::Sub | BinOp_::Mul | BinOp_::Div | BinOp_::Mod => {
-                        vec!["+", "-", "*", "/", "%"]
-                    },
-                    BinOp_::BitOr | BinOp_::BitAnd | BinOp_::Xor => {
-                        vec!["|", "&", "^"]
-                    },
-                    BinOp_::Shl | BinOp_::Shr => {
-                        vec!["<<", ">>"]
-                    },
-                    _ => vec![],
-                };
-
-                ops.into_iter()
-                    .filter(|v| cur_op != *v)
-                    .map(|op| {
-                        let mut mutated_source = source.to_string();
-                        mutated_source.replace_range(start..end, op);
-                        MutantInfo::new(
-                            mutated_source,
-                            Mutation::new(
-                                Range::new(start, end),
-                                "binary_operator_replacement".to_string(),
-                                cur_op.to_string(),
-                                op.to_string(),
-                            ),
-                        )
-                    })
-                    .collect()
-            },
-            MutationOperator::UnaryOperator(unary_op) => {
-                let start = unary_op.loc.start() as usize;
-                let end = unary_op.loc.end() as usize;
-                let cur_op = &source[start..end];
-
-                // For unary operator mutations, we only need to replace the operator with a space (to ensure the same file length).
-                vec![" "]
-                    .into_iter()
-                    .map(|op| {
-                        let mut mutated_source = source.to_string();
-                        mutated_source.replace_range(start..end, op);
-                        MutantInfo::new(
-                            mutated_source,
-                            Mutation::new(
-                                Range::new(start, end),
-                                "unary_operator_replacement".to_string(),
-                                cur_op.to_string(),
-                                op.to_string(),
-                            ),
-                        )
-                    })
-                    .collect()
-            },
+            MutationOperator::BinaryOperator(bin_op) => bin_op.apply(source),
+            MutationOperator::UnaryOperator(unary_op) => unary_op.apply(source),
         }
     }
 
-    /// Returns the file hash of the file that this mutation operator is in.
-    pub fn get_file_hash(&self) -> FileHash {
+    fn get_file_hash(&self) -> FileHash {
         match self {
-            MutationOperator::BinaryOperator(bin_op) => bin_op.loc.file_hash(),
-            MutationOperator::UnaryOperator(unary_op) => unary_op.loc.file_hash(),
+            MutationOperator::BinaryOperator(bin_op) => bin_op.get_file_hash(),
+            MutationOperator::UnaryOperator(unary_op) => unary_op.get_file_hash(),
         }
     }
 }
@@ -118,22 +71,8 @@ impl MutationOperator {
 impl fmt::Display for MutationOperator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            MutationOperator::BinaryOperator(bin_op) => write!(
-                f,
-                "BinaryOperator({}, location: file hash: {}, index start: {}, index stop: {})",
-                bin_op.value,
-                bin_op.loc.file_hash(),
-                bin_op.loc.start(),
-                bin_op.loc.end()
-            ),
-            MutationOperator::UnaryOperator(unary_op) => write!(
-                f,
-                "UnaryOperator({}, location: file hash: {}, index start: {}, index stop: {})",
-                unary_op.value,
-                unary_op.loc.file_hash(),
-                unary_op.loc.start(),
-                unary_op.loc.end()
-            ),
+            MutationOperator::BinaryOperator(bin_op) => write!(f, "{}", bin_op),
+            MutationOperator::UnaryOperator(unary_op) => write!(f, "{}", unary_op),
         }
     }
 }
@@ -152,7 +91,7 @@ mod tests {
             value: BinOp_::Mul,
             loc,
         };
-        let operator = MutationOperator::BinaryOperator(bin_op);
+        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(bin_op));
         let source = "*";
         let expected = vec!["+", "-", "/", "%"];
         let result = operator.apply(source);
@@ -169,7 +108,7 @@ mod tests {
             value: UnaryOp_::Not,
             loc,
         };
-        let operator = MutationOperator::UnaryOperator(unary_op);
+        let operator = MutationOperator::UnaryOperator(UnaryOperator::new(unary_op));
         let source = "!";
         let expected = vec![" "];
         let result = operator.apply(source);
@@ -186,7 +125,7 @@ mod tests {
             value: BinOp_::Add,
             loc,
         };
-        let operator = MutationOperator::BinaryOperator(bin_op);
+        let operator = MutationOperator::BinaryOperator(BinaryOperator::new(bin_op));
         assert_eq!(operator.get_file_hash(), FileHash::new(""));
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/binary.rs
+++ b/third_party/move/tools/move-mutator/src/operators/binary.rs
@@ -1,4 +1,4 @@
-use crate::operator::{MutantInfo, MutationOperatorTrait};
+use crate::operator::{MutantInfo, MutationOperator};
 use crate::report::{Mutation, Range};
 use move_command_line_common::files::FileHash;
 use move_compiler::parser::ast::{BinOp, BinOp_};
@@ -6,17 +6,17 @@ use std::fmt;
 
 /// The binary mutation operator.
 #[derive(Debug, Copy, Clone)]
-pub struct BinaryOperator {
+pub struct Binary {
     operation: BinOp,
 }
 
-impl BinaryOperator {
+impl Binary {
     pub fn new(operation: BinOp) -> Self {
         Self { operation }
     }
 }
 
-impl MutationOperatorTrait for BinaryOperator {
+impl MutationOperator for Binary {
     fn apply(&self, source: &str) -> Vec<MutantInfo> {
         let start = self.operation.loc.start() as usize;
         let end = self.operation.loc.end() as usize;
@@ -60,7 +60,7 @@ impl MutationOperatorTrait for BinaryOperator {
     }
 }
 
-impl fmt::Display for BinaryOperator {
+impl fmt::Display for Binary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -87,7 +87,7 @@ mod tests {
             value: BinOp_::Add,
             loc,
         };
-        let operator = BinaryOperator::new(bin_op);
+        let operator = Binary::new(bin_op);
         let source = "+";
         let expected = vec!["-", "*", "/", "%"];
         let result = operator.apply(source);
@@ -104,7 +104,7 @@ mod tests {
             value: BinOp_::Add,
             loc,
         };
-        let operator = BinaryOperator::new(bin_op);
+        let operator = Binary::new(bin_op);
         assert_eq!(operator.get_file_hash(), FileHash::new(""));
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/binary.rs
+++ b/third_party/move/tools/move-mutator/src/operators/binary.rs
@@ -1,0 +1,110 @@
+use crate::operator::{MutantInfo, MutationOperatorTrait};
+use crate::report::{Mutation, Range};
+use move_command_line_common::files::FileHash;
+use move_compiler::parser::ast::{BinOp, BinOp_};
+use std::fmt;
+
+/// The binary mutation operator.
+#[derive(Debug, Copy, Clone)]
+pub struct BinaryOperator {
+    operation: BinOp,
+}
+
+impl BinaryOperator {
+    pub fn new(operation: BinOp) -> Self {
+        Self { operation }
+    }
+}
+
+impl MutationOperatorTrait for BinaryOperator {
+    fn apply(&self, source: &str) -> Vec<MutantInfo> {
+        let start = self.operation.loc.start() as usize;
+        let end = self.operation.loc.end() as usize;
+        let cur_op = &source[start..end];
+
+        // Group of exchangeable binary operators - we only want to replace the operator with a different one
+        // within the same group.
+        let ops: Vec<&str> = match self.operation.value {
+            BinOp_::Add | BinOp_::Sub | BinOp_::Mul | BinOp_::Div | BinOp_::Mod => {
+                vec!["+", "-", "*", "/", "%"]
+            },
+            BinOp_::BitOr | BinOp_::BitAnd | BinOp_::Xor => {
+                vec!["|", "&", "^"]
+            },
+            BinOp_::Shl | BinOp_::Shr => {
+                vec!["<<", ">>"]
+            },
+            _ => vec![],
+        };
+
+        ops.into_iter()
+            .filter(|v| cur_op != *v)
+            .map(|op| {
+                let mut mutated_source = source.to_string();
+                mutated_source.replace_range(start..end, op);
+                MutantInfo::new(
+                    mutated_source,
+                    Mutation::new(
+                        Range::new(start, end),
+                        "binary_operator_replacement".to_string(),
+                        cur_op.to_string(),
+                        op.to_string(),
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn get_file_hash(&self) -> FileHash {
+        self.operation.loc.file_hash()
+    }
+}
+
+impl fmt::Display for BinaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "BinaryOperator({}, location: file hash: {}, index start: {}, index stop: {})",
+            self.operation.value,
+            self.operation.loc.file_hash(),
+            self.operation.loc.start(),
+            self.operation.loc.end()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_command_line_common::files::FileHash;
+    use move_compiler::parser::ast::{BinOp, BinOp_};
+    use move_ir_types::location::Loc;
+
+    #[test]
+    fn test_apply_binary_operator() {
+        let loc = Loc::new(FileHash::new(""), 0, 1);
+        let bin_op = BinOp {
+            value: BinOp_::Add,
+            loc,
+        };
+        let operator = BinaryOperator::new(bin_op);
+        let source = "+";
+        let expected = vec!["-", "*", "/", "%"];
+        let result = operator.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
+    }
+
+    #[test]
+    fn test_get_file_hash() {
+        let loc = Loc::new(FileHash::new(""), 0, 0);
+        let bin_op = BinOp {
+            value: BinOp_::Add,
+            loc,
+        };
+        let operator = BinaryOperator::new(bin_op);
+        assert_eq!(operator.get_file_hash(), FileHash::new(""));
+    }
+}

--- a/third_party/move/tools/move-mutator/src/operators/mod.rs
+++ b/third_party/move/tools/move-mutator/src/operators/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod binary;
+pub(crate) mod unary;

--- a/third_party/move/tools/move-mutator/src/operators/unary.rs
+++ b/third_party/move/tools/move-mutator/src/operators/unary.rs
@@ -1,21 +1,21 @@
-use crate::operator::{MutantInfo, MutationOperatorTrait};
+use crate::operator::{MutantInfo, MutationOperator};
 use crate::report::{Mutation, Range};
 use move_command_line_common::files::FileHash;
 use move_compiler::parser::ast::UnaryOp;
 use std::fmt;
 
 #[derive(Debug, Copy, Clone)]
-pub struct UnaryOperator {
+pub struct Unary {
     op: UnaryOp,
 }
 
-impl UnaryOperator {
+impl Unary {
     pub fn new(op: UnaryOp) -> Self {
         Self { op }
     }
 }
 
-impl MutationOperatorTrait for UnaryOperator {
+impl MutationOperator for Unary {
     fn apply(&self, source: &str) -> Vec<MutantInfo> {
         let start = self.op.loc.start() as usize;
         let end = self.op.loc.end() as usize;
@@ -45,7 +45,7 @@ impl MutationOperatorTrait for UnaryOperator {
     }
 }
 
-impl fmt::Display for UnaryOperator {
+impl fmt::Display for Unary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -72,7 +72,7 @@ mod tests {
             value: UnaryOp_::Not,
             loc,
         };
-        let operator = UnaryOperator::new(unary_op);
+        let operator = Unary::new(unary_op);
         let source = "!";
         let expected = vec![" "];
         let result = operator.apply(source);
@@ -89,7 +89,7 @@ mod tests {
             value: UnaryOp_::Not,
             loc,
         };
-        let operator = UnaryOperator::new(unary_op);
+        let operator = Unary::new(unary_op);
         assert_eq!(operator.get_file_hash(), FileHash::new(""));
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/unary.rs
+++ b/third_party/move/tools/move-mutator/src/operators/unary.rs
@@ -1,0 +1,95 @@
+use crate::operator::{MutantInfo, MutationOperatorTrait};
+use crate::report::{Mutation, Range};
+use move_command_line_common::files::FileHash;
+use move_compiler::parser::ast::UnaryOp;
+use std::fmt;
+
+#[derive(Debug, Copy, Clone)]
+pub struct UnaryOperator {
+    op: UnaryOp,
+}
+
+impl UnaryOperator {
+    pub fn new(op: UnaryOp) -> Self {
+        Self { op }
+    }
+}
+
+impl MutationOperatorTrait for UnaryOperator {
+    fn apply(&self, source: &str) -> Vec<MutantInfo> {
+        let start = self.op.loc.start() as usize;
+        let end = self.op.loc.end() as usize;
+        let cur_op = &source[start..end];
+
+        // For unary operator mutations, we only need to replace the operator with a space (to ensure the same file length).
+        vec![" "]
+            .into_iter()
+            .map(|op| {
+                let mut mutated_source = source.to_string();
+                mutated_source.replace_range(start..end, op);
+                MutantInfo::new(
+                    mutated_source,
+                    Mutation::new(
+                        Range::new(start, end),
+                        "unary_operator_replacement".to_string(),
+                        cur_op.to_string(),
+                        op.to_string(),
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn get_file_hash(&self) -> FileHash {
+        self.op.loc.file_hash()
+    }
+}
+
+impl fmt::Display for UnaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "UnaryOperator({}, location: file hash: {}, index start: {}, index stop: {})",
+            self.op.value,
+            self.op.loc.file_hash(),
+            self.op.loc.start(),
+            self.op.loc.end()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_command_line_common::files::FileHash;
+    use move_compiler::parser::ast::{UnaryOp, UnaryOp_};
+    use move_ir_types::location::Loc;
+
+    #[test]
+    fn test_apply_unary_operator() {
+        let loc = Loc::new(FileHash::new(""), 0, 1);
+        let unary_op = UnaryOp {
+            value: UnaryOp_::Not,
+            loc,
+        };
+        let operator = UnaryOperator::new(unary_op);
+        let source = "!";
+        let expected = vec![" "];
+        let result = operator.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
+    }
+
+    #[test]
+    fn test_get_file_hash() {
+        let loc = Loc::new(FileHash::new(""), 0, 0);
+        let unary_op = UnaryOp {
+            value: UnaryOp_::Not,
+            loc,
+        };
+        let operator = UnaryOperator::new(unary_op);
+        assert_eq!(operator.get_file_hash(), FileHash::new(""));
+    }
+}


### PR DESCRIPTION
### Description

Technical PR - no new features.

Mutation operators has been refactored. Now, there is a main trait which needs to be implemented by each new operator.

Operators are now separated from each other - they are under new subdirectory, each operator in its own file.

### Test Plan
All tests has been updated to reflect changes in the code.
