### PR TITLE
[move-mutator][move-spec-test] set of minor features and improvements

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.3", features = ["derive"] }
 diffy = "0.3"
 log = "0.4"
 pretty_env_logger = "0.5"
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.9"

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -60,6 +60,7 @@ JSON report format sample:
       {
         "mutant_path": "mutants_output/shift_0.move",
         "original_file": "third_party/move/move-prover/tests/sources/functional/shift.move",
+        "module_name": "module",
         "mutations": [
           {
             "changed_place": {
@@ -81,6 +82,7 @@ Text format sample:
 ```
 Mutant path: mutants_output/shift_0.move
 Original file: third_party/move/move-prover/tests/sources/functional/shift.move
+Module name: module
 Mutations:
   Operator: binary_operator_replacement
   Old value: <<

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -130,7 +130,15 @@ The above means that the operator tool can produce many mutants within one place
 
 Once generated, mutants can be checked to see if they are valid. It's possible to run the Move compiler to check if the mutant is valid, as some of the mutations can create mutants that cannot be compiled properly.
 
-The last module in the main logic layer filters the mutants and reduces the outcome.
+The last module in the main logic layer filters the mutants and reduces the outcome. Filtering is done using `ratio` given in the configuration file or CLI. `ratio` factor works as wollows:
+- if `ratio` is 1, no mutants are returned,
+- if `ratio` is 2, averagely 50% mutants are returned,
+- if `ratio` is 3, averagely 66% mutants are returned,
+- and so on - `ratio` says how often mutant should be removed.
+
+There is additional behaviour:
+- mutator tries to return at least one mutant per file,
+- mutator tries to return at least one mutant per mutation operator.
 
 ### Data layer
 

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -130,11 +130,7 @@ The above means that the operator tool can produce many mutants within one place
 
 Once generated, mutants can be checked to see if they are valid. It's possible to run the Move compiler to check if the mutant is valid, as some of the mutations can create mutants that cannot be compiled properly.
 
-The last module in the main logic layer filters the mutants and reduces the outcome. Filtering is done using `ratio` given in the configuration file or CLI. `ratio` factor works as wollows:
-- if `ratio` is 1, no mutants are returned,
-- if `ratio` is 2, averagely 50% mutants are returned,
-- if `ratio` is 3, averagely 66% mutants are returned,
-- and so on - `ratio` says how often mutant should be removed.
+The last module in the main logic layer filters the mutants and reduces the outcome. Filtering is done using percentage parameter which means how many mutants should be rejected.
 
 There is additional behaviour:
 - mutator tries to return at least one mutant per file,

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -26,9 +26,9 @@ pub struct CLIOptions {
     /// Name of the filter to use for downsampling. Downsampling reduces the amount of mutants to the desired amount.
     #[clap(long, hide = true)]
     pub downsample_filter: Option<String>,
-    /// Maximum number of mutants to be generated. If not specified, downsampling will be disabled. Currently only random filter is supported (mutants are removed randomly).
+    /// Remove averagely n-th mutant. 2 means 50% reduction, 3 means 33% reduction, etc. See the doc for more details.
     #[clap(long)]
-    pub downsample_num: Option<u64>,
+    pub downsample_ratio: Option<u64>,
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
@@ -46,7 +46,7 @@ impl Default for CLIOptions {
             verify_mutants: true,
             no_overwrite: None,
             downsample_filter: None,
-            downsample_num: None,
+            downsample_ratio: None,
             configuration_file: None,
         }
     }

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -54,7 +54,7 @@ impl Default for CLIOptions {
 }
 
 /// Filter allowing to select modules to be mutated.
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub enum ModuleFilter {
     #[default]
     All,

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 pub const DEFAULT_OUTPUT_DIR: &str = "mutants_output";
 
@@ -12,8 +13,8 @@ pub struct CLIOptions {
     #[clap(long, short, value_parser)]
     pub move_sources: Vec<PathBuf>,
     /// Module names to be mutated.
-    #[clap(long)]
-    pub mutate_modules: Option<Vec<String>>,
+    #[clap(long, value_parser, default_value = "all")]
+    pub mutate_modules: ModuleFilter,
     /// The path where to put the output files.
     #[clap(long, short, value_parser)]
     pub out_mutant_dir: Option<PathBuf>,
@@ -41,13 +42,32 @@ impl Default for CLIOptions {
     fn default() -> Self {
         Self {
             move_sources: vec![],
-            mutate_modules: None,
+            mutate_modules: ModuleFilter::All,
             out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: true,
             no_overwrite: None,
             downsample_filter: None,
             downsample_ratio: None,
             configuration_file: None,
+        }
+    }
+}
+
+/// Filter allowing to select modules to be mutated.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub enum ModuleFilter {
+    #[default]
+    All,
+    Selected(Vec<String>),
+}
+
+impl FromStr for ModuleFilter {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(ModuleFilter::All),
+            _ => Ok(ModuleFilter::Selected(vec![s.to_string()])),
         }
     }
 }

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -11,12 +11,9 @@ pub struct CLIOptions {
     /// The paths to the Move sources.
     #[clap(long, short, value_parser)]
     pub move_sources: Vec<PathBuf>,
-    /// The paths to the Move sources to include.
-    #[clap(long, short, value_parser)]
-    pub include_only_files: Option<Vec<PathBuf>>,
-    /// The paths to the Move sources to exclude.
-    #[clap(long, short, value_parser)]
-    pub exclude_files: Option<Vec<PathBuf>>,
+    /// Module names to be mutated.
+    #[clap(long)]
+    pub mutate_modules: Option<Vec<String>>,
     /// The path where to put the output files.
     #[clap(long, short, value_parser)]
     pub out_mutant_dir: Option<PathBuf>,
@@ -44,8 +41,7 @@ impl Default for CLIOptions {
     fn default() -> Self {
         Self {
             move_sources: vec![],
-            include_only_files: None,
-            exclude_files: None,
+            mutate_modules: None,
             out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: true,
             no_overwrite: None,

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -27,9 +27,9 @@ pub struct CLIOptions {
     /// Name of the filter to use for downsampling. Downsampling reduces the amount of mutants to the desired amount.
     #[clap(long, hide = true)]
     pub downsample_filter: Option<String>,
-    /// Remove averagely n-th mutant. 2 means 50% reduction, 3 means 33% reduction, etc. See the doc for more details.
+    /// Remove averagely given percentage of mutants. See the doc for more details.
     #[clap(long)]
-    pub downsample_ratio: Option<u64>,
+    pub downsampling_ratio_percentage: Option<u64>,
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,
@@ -47,7 +47,7 @@ impl Default for CLIOptions {
             verify_mutants: true,
             no_overwrite: None,
             downsample_filter: None,
-            downsample_ratio: None,
+            downsampling_ratio_percentage: None,
             configuration_file: None,
         }
     }

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -149,8 +149,7 @@ mod tests {
             {
                 "project": {
                     "move_sources": ["/path/to/move/source"],
-                    "include_only_files": ["/path/to/include/file"],
-                    "exclude_files": ["/path/to/exclude/file"],
+                    "mutate_modules": ["mod1"],
                     "out_mutant_dir": "/path/to/output",
                     "verify_mutants": true,
                     "no_overwrite": false,
@@ -184,12 +183,8 @@ mod tests {
             vec![Path::new("/path/to/move/source")]
         );
         assert_eq!(
-            config.project.include_only_files.unwrap(),
-            vec![Path::new("/path/to/include/file")]
-        );
-        assert_eq!(
-            config.project.exclude_files.unwrap(),
-            vec![Path::new("/path/to/exclude/file")]
+            config.project.mutate_modules.unwrap(),
+            vec!["mod1".to_string()]
         );
         assert_eq!(
             config.project.out_mutant_dir,

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -102,6 +102,7 @@ pub struct FileConfiguration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::ModuleFilter;
     use std::fs;
     use std::path::Path;
 
@@ -155,7 +156,7 @@ mod tests {
             {
                 "project": {
                     "move_sources": ["/path/to/move/source"],
-                    "mutate_modules": ["mod1"],
+                    "mutate_modules": "all",
                     "out_mutant_dir": "/path/to/output",
                     "verify_mutants": true,
                     "no_overwrite": false,
@@ -187,10 +188,7 @@ mod tests {
             config.project.move_sources,
             vec![Path::new("/path/to/move/source")]
         );
-        assert_eq!(
-            config.project.mutate_modules.unwrap(),
-            vec!["mod1".to_string()]
-        );
+        assert_eq!(config.project.mutate_modules.unwrap(), ModuleFilter::All);
         assert_eq!(
             config.project.out_mutant_dir,
             Some(PathBuf::from("/path/to/output"))

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -156,7 +156,7 @@ mod tests {
             {
                 "project": {
                     "move_sources": ["/path/to/move/source"],
-                    "mutate_modules": "all",
+                    "mutate_modules": "All",
                     "out_mutant_dir": "/path/to/output",
                     "verify_mutants": true,
                     "no_overwrite": false,
@@ -188,7 +188,7 @@ mod tests {
             config.project.move_sources,
             vec![Path::new("/path/to/move/source")]
         );
-        assert_eq!(config.project.mutate_modules.unwrap(), ModuleFilter::All);
+        assert_eq!(config.project.mutate_modules, ModuleFilter::All);
         assert_eq!(
             config.project.out_mutant_dir,
             Some(PathBuf::from("/path/to/output"))

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -96,25 +96,25 @@ pub struct FileConfiguration {
     pub verify_mutants: Option<bool>,
     /// Names of the mutation operators to use. If not provided, all operators will be used.
     pub mutation_operators: Option<MutationConfig>,
-    /// Mutate only the functions with the given names (otherwise, mutate all).
-    pub include_functions: IncludeFunctionsFilter,
+    /// Mutate only the functions with the given names.
+    pub include_functions: IncludeFunctions,
 }
 
 /// Filter for the functions to mutate.
 #[derive(Default, Debug, Clone, Deserialize, Serialize, PartialEq)]
-pub enum IncludeFunctionsFilter {
+pub enum IncludeFunctions {
     #[default]
     All,
     Selected(Vec<String>),
 }
 
-impl FromStr for IncludeFunctionsFilter {
+impl FromStr for IncludeFunctions {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "all" => Ok(IncludeFunctionsFilter::All),
-            _ => Ok(IncludeFunctionsFilter::Selected(vec![s.to_string()])),
+            "all" => Ok(IncludeFunctions::All),
+            _ => Ok(IncludeFunctions::Selected(vec![s.to_string()])),
         }
     }
 }
@@ -277,7 +277,7 @@ mod tests {
             file: file_path.clone(),
             verify_mutants: Some(true),
             mutation_operators: None,
-            include_functions: IncludeFunctionsFilter::All,
+            include_functions: IncludeFunctions::All,
         };
         let config = Configuration {
             project: CLIOptions::default(),

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -111,6 +111,7 @@ pub fn run_move_mutator(
                 let mut entry = report::MutationReport::new(
                     mutant_path.as_path(),
                     path,
+                    mutant.get_module_name().unwrap().0.value.as_str(),
                     &mutated.mutated_source,
                     &source,
                 );

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -60,7 +60,7 @@ pub fn run_move_mutator(
     trace!("Mutator configuration: {mutator_configuration:?}");
 
     let (files, ast) = generate_ast(&mutator_configuration, config, package_path)?;
-    let mutants = mutate::mutate(ast, &mutator_configuration)?;
+    let mutants = mutate::mutate(ast, &mutator_configuration, &files)?;
     let output_dir = output::setup_output_dir(&mutator_configuration)?;
     let mut report: Report = Report::new();
 

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -1,5 +1,6 @@
 use crate::operator::{MutantInfo, MutationOp, MutationOperator};
 use move_command_line_common::files::FileHash;
+use move_compiler::parser::ast::ModuleName;
 use std::fmt;
 
 /// A mutant is a piece of code that has been mutated by the mutation operator.
@@ -7,12 +8,16 @@ use std::fmt;
 #[derive(Debug, Clone)]
 pub struct Mutant {
     operator: MutationOp,
+    module_name: Option<ModuleName>,
 }
 
 impl Mutant {
     /// Creates a new mutant.
-    pub fn new(operator: MutationOp) -> Self {
-        Self { operator }
+    pub fn new(operator: MutationOp, module_name: Option<ModuleName>) -> Self {
+        Self {
+            operator,
+            module_name,
+        }
     }
 
     /// Returns the file hash of the file that this mutant is in.
@@ -26,6 +31,16 @@ impl Mutant {
         trace!("Applying mutation operator: {}", self.operator);
         self.operator.apply(source)
     }
+
+    /// Returns the module name that this mutant is in.
+    pub fn get_module_name(&self) -> Option<ModuleName> {
+        self.module_name.clone()
+    }
+
+    /// Sets the module name that this mutant is in.
+    pub fn set_module_name(&mut self, module_name: ModuleName) {
+        self.module_name = Some(module_name);
+    }
 }
 
 impl fmt::Display for Mutant {
@@ -37,10 +52,10 @@ impl fmt::Display for Mutant {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::operators::binary::Binary;
     use move_command_line_common::files::FileHash;
     use move_compiler::parser::ast::{BinOp, BinOp_};
     use move_ir_types::location::Loc;
-    use crate::operators::binary::Binary;
 
     #[test]
     fn test_new() {
@@ -49,7 +64,7 @@ mod tests {
             value: BinOp_::Add,
             loc,
         }));
-        let mutant = Mutant::new(operator);
+        let mutant = Mutant::new(operator, None);
         assert_eq!(format!("{}", mutant), "Mutant: BinaryOperator(+, location: file hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, index start: 0, index stop: 0)");
     }
 
@@ -60,7 +75,7 @@ mod tests {
             value: BinOp_::Add,
             loc,
         }));
-        let mutant = Mutant::new(operator);
+        let mutant = Mutant::new(operator, None);
         assert_eq!(mutant.get_file_hash(), FileHash::new(""));
     }
 
@@ -71,7 +86,7 @@ mod tests {
             value: BinOp_::Add,
             loc,
         }));
-        let mutant = Mutant::new(operator);
+        let mutant = Mutant::new(operator, None);
         let source = "+";
         let expected = vec!["-", "*", "/", "%"];
         let result = mutant.apply(source);

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -1,3 +1,4 @@
+use crate::cli;
 use crate::configuration::Configuration;
 use move_compiler::diagnostics::FilesSourceText;
 use move_compiler::parser::ast;
@@ -47,14 +48,11 @@ fn traverse_module(
     conf: &Configuration,
     files: &FilesSourceText,
 ) -> anyhow::Result<Vec<Mutant>> {
-    if conf
-        .project
-        .mutate_modules
-        .as_ref()
-        .is_some_and(|modules| !modules.contains(&module.name.to_string()))
-    {
-        trace!("Skipping module {}", module.name);
-        return Ok(vec![]);
+    if let cli::ModuleFilter::Selected(mods) = &conf.project.mutate_modules {
+        if !mods.contains(&module.name.to_string()) {
+            trace!("Skipping module {}", module.name.to_string());
+            return Ok(vec![]);
+        }
     }
 
     trace!("Traversing module {}", module.name);

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -1,5 +1,5 @@
 use crate::cli;
-use crate::configuration::Configuration;
+use crate::configuration::{Configuration, IncludeFunctionsFilter};
 use move_compiler::diagnostics::FilesSourceText;
 use move_compiler::parser::ast;
 use move_compiler::parser::ast::{
@@ -92,13 +92,11 @@ fn traverse_function(
 
     // Check if function is included in individual configuration.
     if let Some(ind) = conf.get_file_configuration(Path::new(filename.as_str())) {
-        if ind
-            .include_functions
-            .as_ref()
-            .is_some_and(|functions| !functions.contains(&function.name.to_string()))
-        {
-            trace!("Skipping function {}", function.name);
-            return Ok(vec![]);
+        if let IncludeFunctionsFilter::Selected(funcs) = &ind.include_functions {
+            if !funcs.contains(&function.name.to_string()) {
+                trace!("Skipping function {}", &function.name.to_string());
+                return Ok(vec![]);
+            }
         }
     }
 

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::fmt::Debug;
 
 /// Mutation result that contains the mutated source code and the modification that was applied.
+#[derive(Debug, Clone, PartialEq)]
 pub struct MutantInfo {
     /// The mutated source code.
     pub mutated_source: String,
@@ -44,7 +45,7 @@ pub trait MutationOperator {
 }
 
 /// The mutation operator to apply.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum MutationOp {
     BinaryOp(Binary),
     UnaryOp(Unary),

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -96,7 +96,7 @@ impl Default for Report {
 
 /// The `Range` struct represents a range with a start and end.
 /// It is used to represent the location of a mutation inside the source file.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Range {
     /// The start of the range.
     start: usize,
@@ -119,7 +119,7 @@ impl Range {
 /// The `Mutation` struct represents a modification that was applied to a file.
 /// It contains the location of the modification, the name of the mutation operator, the old value and the new value.
 /// It is used to represent a single modification inside a `ReportEntry`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Mutation {
     /// The location of the modification.
     changed_place: Range,

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -203,6 +203,12 @@ impl MutationReport {
     pub fn original_file_path(&self) -> &PathBuf {
         &self.original_file
     }
+
+    /// Return the module name.
+    #[must_use]
+    pub fn get_module_name(&self) -> &str {
+        &self.module_name
+    }
 }
 
 #[cfg(test)]

--- a/third_party/move/tools/move-spec-test/README.md
+++ b/third_party/move/tools/move-spec-test/README.md
@@ -35,17 +35,37 @@ There should be output generated similar to the following:
 Total mutants tested: 4
 Total mutants killed: 4
 
-╭─────────────────────────────────┬────────────────┬────────────────┬────────────╮
-│ File                            │ Mutants tested │ Mutants killed │ Percentage │
-├─────────────────────────────────┼────────────────┼────────────────┼────────────┤
-│ ./sources/m2/Negation.move      │ 1              │ 1              │ 100.00%    │
-├─────────────────────────────────┼────────────────┼────────────────┼────────────┤
-│ ./sources/m1/Negation.move      │ 1              │ 1              │ 100.00%    │
-├─────────────────────────────────┼────────────────┼────────────────┼────────────┤
-│ ./sources/Negation.move         │ 1              │ 1              │ 100.00%    │
-├─────────────────────────────────┼────────────────┼────────────────┼────────────┤
-│ ./sources/m1/m1_1/Negation.move │ 1              │ 1              │ 100.00%    │
-╰─────────────────────────────────┴────────────────┴────────────────┴────────────╯
+Statistics for file: ./sources/m1/Negation.move
+╭─────────────┬────────────────┬────────────────┬────────────╮
+│ Module      │ Mutants tested │ Mutants killed │ Percentage │
+├─────────────┼────────────────┼────────────────┼────────────┤
+│ Negation_m1 │ 1              │ 1              │ 100.00%    │
+╰─────────────┴────────────────┴────────────────┴────────────╯
+
+
+Statistics for file: ./sources/m2/Negation.move
+╭─────────────┬────────────────┬────────────────┬────────────╮
+│ Module      │ Mutants tested │ Mutants killed │ Percentage │
+├─────────────┼────────────────┼────────────────┼────────────┤
+│ Negation_m2 │ 1              │ 1              │ 100.00%    │
+╰─────────────┴────────────────┴────────────────┴────────────╯
+
+
+Statistics for file: ./sources/Negation.move
+╭───────────────┬────────────────┬────────────────┬────────────╮
+│ Module        │ Mutants tested │ Mutants killed │ Percentage │
+├───────────────┼────────────────┼────────────────┼────────────┤
+│ Negation_main │ 1              │ 1              │ 100.00%    │
+╰───────────────┴────────────────┴────────────────┴────────────╯
+
+
+Statistics for file: ./sources/m1/m1_1/Negation.move
+╭───────────────┬────────────────┬────────────────┬────────────╮
+│ Module        │ Mutants tested │ Mutants killed │ Percentage │
+├───────────────┼────────────────┼────────────────┼────────────┤
+│ Negation_m1_1 │ 1              │ 1              │ 100.00%    │
+╰───────────────┴────────────────┴────────────────┴────────────╯
+
 ```
 
 Specification testing tool respects `RUST_LOG` variable, and it will print out as much information as the variable allows. There is possibility to enable logging only for the specific modules. Please refer to the [env_logger](https://docs.rs/env_logger/latest/env_logger/) documentation for more details.

--- a/third_party/move/tools/move-spec-test/README.md
+++ b/third_party/move/tools/move-spec-test/README.md
@@ -35,37 +35,17 @@ There should be output generated similar to the following:
 Total mutants tested: 4
 Total mutants killed: 4
 
-Statistics for file: ./sources/m1/Negation.move
-╭─────────────┬────────────────┬────────────────┬────────────╮
-│ Module      │ Mutants tested │ Mutants killed │ Percentage │
-├─────────────┼────────────────┼────────────────┼────────────┤
-│ Negation_m1 │ 1              │ 1              │ 100.00%    │
-╰─────────────┴────────────────┴────────────────┴────────────╯
-
-
-Statistics for file: ./sources/m2/Negation.move
-╭─────────────┬────────────────┬────────────────┬────────────╮
-│ Module      │ Mutants tested │ Mutants killed │ Percentage │
-├─────────────┼────────────────┼────────────────┼────────────┤
-│ Negation_m2 │ 1              │ 1              │ 100.00%    │
-╰─────────────┴────────────────┴────────────────┴────────────╯
-
-
-Statistics for file: ./sources/Negation.move
-╭───────────────┬────────────────┬────────────────┬────────────╮
-│ Module        │ Mutants tested │ Mutants killed │ Percentage │
-├───────────────┼────────────────┼────────────────┼────────────┤
-│ Negation_main │ 1              │ 1              │ 100.00%    │
-╰───────────────┴────────────────┴────────────────┴────────────╯
-
-
-Statistics for file: ./sources/m1/m1_1/Negation.move
-╭───────────────┬────────────────┬────────────────┬────────────╮
-│ Module        │ Mutants tested │ Mutants killed │ Percentage │
-├───────────────┼────────────────┼────────────────┼────────────┤
-│ Negation_m1_1 │ 1              │ 1              │ 100.00%    │
-╰───────────────┴────────────────┴────────────────┴────────────╯
-
+╭────────────────────────────────────────────────┬────────────────┬────────────────┬────────────╮
+│ Module                                         │ Mutants tested │ Mutants killed │ Percentage │
+├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
+│ ./sources/m1/m1_1/Negation.move::Negation_m1_1 │ 1              │ 1              │ 100.00%    │
+├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
+│ ./sources/m2/Negation.move::Negation_m2        │ 1              │ 1              │ 100.00%    │
+├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
+│ ./sources/m1/Negation.move::Negation_m1        │ 1              │ 1              │ 100.00%    │
+├────────────────────────────────────────────────┼────────────────┼────────────────┼────────────┤
+│ ./sources/Negation.move::Negation_main         │ 1              │ 1              │ 100.00%    │
+╰────────────────────────────────────────────────┴────────────────┴────────────────┴────────────╯
 ```
 
 Specification testing tool respects `RUST_LOG` variable, and it will print out as much information as the variable allows. There is possibility to enable logging only for the specific modules. Please refer to the [env_logger](https://docs.rs/env_logger/latest/env_logger/) documentation for more details.

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -9,12 +9,9 @@ pub struct CLIOptions {
     /// The paths to the Move sources.
     #[clap(long, short, value_parser)]
     pub move_sources: Vec<PathBuf>,
-    /// The paths to the Move sources to include.
-    #[clap(long, short, value_parser)]
-    pub include_only_files: Option<Vec<PathBuf>>,
-    /// The paths to the Move sources to exclude.
-    #[clap(long, short, value_parser)]
-    pub exclude_files: Option<Vec<PathBuf>>,
+    /// Work only over specified modules.
+    #[clap(long, short)]
+    pub include_modules: Option<Vec<String>>,
     /// Optional configuration file for mutator tool.
     #[clap(long, value_parser)]
     pub mutator_conf: Option<PathBuf>,
@@ -34,8 +31,7 @@ pub struct CLIOptions {
 pub fn create_mutator_options(options: &CLIOptions) -> move_mutator::cli::CLIOptions {
     move_mutator::cli::CLIOptions {
         move_sources: options.move_sources.clone(),
-        include_only_files: options.include_only_files.clone(),
-        exclude_files: options.exclude_files.clone(),
+        mutate_modules: options.include_modules.clone(),
         configuration_file: options.mutator_conf.clone(),
         ..Default::default()
     }
@@ -82,8 +78,7 @@ mod tests {
     fn cli_options_starts_empty() {
         let options = CLIOptions::default();
         assert!(options.move_sources.is_empty());
-        assert!(options.include_only_files.is_none());
-        assert!(options.exclude_files.is_none());
+        assert!(options.include_modules.is_none());
         assert!(options.mutator_conf.is_none());
         assert!(options.prover_conf.is_none());
         assert!(options.output.is_none());
@@ -94,18 +89,16 @@ mod tests {
     fn create_mutator_options_copies_fields() {
         let mut options = CLIOptions::default();
         options.move_sources.push(PathBuf::from("path/to/file"));
-        options.include_only_files = Some(vec![PathBuf::from("path/to/include")]);
-        options.exclude_files = Some(vec![PathBuf::from("path/to/exclude")]);
+        options.include_modules = Some(vec!["test1".to_string(), "test2".to_string()]);
         options.mutator_conf = Some(PathBuf::from("path/to/mutator/conf"));
 
         let mutator_options = create_mutator_options(&options);
 
         assert_eq!(mutator_options.move_sources, options.move_sources);
         assert_eq!(
-            mutator_options.include_only_files,
-            options.include_only_files
+            mutator_options.mutate_modules,
+            options.include_modules
         );
-        assert_eq!(mutator_options.exclude_files, options.exclude_files);
         assert_eq!(mutator_options.configuration_file, options.mutator_conf);
     }
 

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use move_mutator::cli::ModuleFilter;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -10,8 +11,8 @@ pub struct CLIOptions {
     #[clap(long, short, value_parser)]
     pub move_sources: Vec<PathBuf>,
     /// Work only over specified modules.
-    #[clap(long, short)]
-    pub include_modules: Option<Vec<String>>,
+    #[clap(long, short, value_parser, default_value = "all")]
+    pub include_modules: ModuleFilter,
     /// Optional configuration file for mutator tool.
     #[clap(long, value_parser)]
     pub mutator_conf: Option<PathBuf>,
@@ -89,7 +90,8 @@ mod tests {
     fn create_mutator_options_copies_fields() {
         let mut options = CLIOptions::default();
         options.move_sources.push(PathBuf::from("path/to/file"));
-        options.include_modules = Some(vec!["test1".to_string(), "test2".to_string()]);
+        options.include_modules =
+            ModuleFilter::Selected(vec!["test1".to_string(), "test2".to_string()]);
         options.mutator_conf = Some(PathBuf::from("path/to/mutator/conf"));
 
         let mutator_options = create_mutator_options(&options);

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -79,7 +79,7 @@ mod tests {
     fn cli_options_starts_empty() {
         let options = CLIOptions::default();
         assert!(options.move_sources.is_empty());
-        assert!(options.include_modules.is_none());
+        assert_eq!(ModuleFilter::All, options.include_modules);
         assert!(options.mutator_conf.is_none());
         assert!(options.prover_conf.is_none());
         assert!(options.output.is_none());

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -95,10 +95,7 @@ mod tests {
         let mutator_options = create_mutator_options(&options);
 
         assert_eq!(mutator_options.move_sources, options.move_sources);
-        assert_eq!(
-            mutator_options.mutate_modules,
-            options.include_modules
-        );
+        assert_eq!(mutator_options.mutate_modules, options.include_modules);
         assert_eq!(mutator_options.configuration_file, options.mutator_conf);
     }
 

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -81,14 +81,14 @@ pub fn run_spec_test(
     let mut spec_report = report::Report::new();
 
     for elem in report.get_mutants() {
-        spec_report.increment_mutants_tested(&elem.original_file_path());
+        spec_report.increment_mutants_tested(elem.original_file_path(), elem.get_module_name());
 
         let mutant_file = elem.mutant_path();
         // Strip prefix to get the path relative to the package directory (or take that path if it's already relative).
         let original_file = elem
             .original_file_path()
             .strip_prefix(package_path)
-            .unwrap_or(&elem.original_file_path());
+            .unwrap_or(elem.original_file_path());
         let outdir_prove = outdir.join("prove");
 
         let _ = fs::remove_dir_all(&outdir_prove);
@@ -110,7 +110,7 @@ pub fn run_spec_test(
 
         if let Err(e) = result {
             trace!("Mutant killed! Prover failed with error: {e}");
-            spec_report.increment_mutants_killed(&elem.original_file_path());
+            spec_report.increment_mutants_killed(elem.original_file_path(), elem.get_module_name());
         } else {
             trace!("Mutant hasn't been killed!");
         }

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -41,7 +41,7 @@ pub fn run_spec_test(
     // (e.g. spec-test). If we use init() instead, we will get an abort.
     let _ = pretty_env_logger::try_init();
 
-    info!("Running spec test {:?}", options);
+    info!("Running spec test {options:?}",);
 
     let mut mutator_conf = cli::create_mutator_options(options);
     let prover_conf = cli::generate_prover_options(options)?;

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -41,7 +41,7 @@ pub fn run_spec_test(
     // (e.g. spec-test). If we use init() instead, we will get an abort.
     let _ = pretty_env_logger::try_init();
 
-    info!("Running spec test");
+    info!("Running spec test {:?}", options);
 
     let mut mutator_conf = cli::create_mutator_options(options);
     let prover_conf = cli::generate_prover_options(options)?;

--- a/third_party/move/tools/move-spec-test/src/report.rs
+++ b/third_party/move/tools/move-spec-test/src/report.rs
@@ -52,25 +52,23 @@ impl Report {
 
     /// Prints the report to stdout in a table format.
     pub fn print_table(&self) {
+        let mut builder = Builder::new();
+        builder.push_record(["Module", "Mutants tested", "Mutants killed", "Percentage"]);
+
         for (path, stats) in &self.files {
-            println!("Statistics for file: {}", path.to_string_lossy());
-
-            let mut builder = Builder::new();
-            builder.push_record(["Module", "Mutants tested", "Mutants killed", "Percentage"]);
-
             for stat in stats {
                 builder.push_record([
-                    stat.module.clone(),
+                    format!("{}::{}", path.to_string_lossy(), stat.module.clone()),
                     stat.tested.to_string(),
                     stat.killed.to_string(),
                     format!("{:.2}%", (stat.killed as f64 / stat.tested as f64) * 100.0),
                 ]);
             }
-
-            let table = builder.build().with(Style::modern_rounded()).to_string();
-
-            println!("{table}\n\n");
         }
+
+        let table = builder.build().with(Style::modern_rounded()).to_string();
+
+        println!("{table}\n\n");
     }
 
     // Internal function to increment the chosen stat.

--- a/third_party/move/tools/move-spec-test/src/report.rs
+++ b/third_party/move/tools/move-spec-test/src/report.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tabled::{builder::Builder, settings::Style};
 
 /// This struct represents a report of the specification testing.
@@ -9,7 +9,7 @@ use tabled::{builder::Builder, settings::Style};
 #[derive(Debug, Serialize)]
 pub struct Report {
     /// The list of entries in the report.
-    files: HashMap<PathBuf, MutantStats>,
+    files: HashMap<PathBuf, Vec<MutantStats>>,
 }
 
 impl Report {
@@ -22,33 +22,25 @@ impl Report {
 
     /// Increments the number of mutants tested for the given path.
     /// If the path is not in the report, it adds it with the number of mutants tested set to 1.
-    pub fn increment_mutants_tested(&mut self, path: &PathBuf) {
-        let entry = self
-            .files
-            .entry(path.clone())
-            .or_insert(MutantStats::default());
-        entry.tested += 1;
+    pub fn increment_mutants_tested(&mut self, path: &Path, module_name: &str) {
+        self.increment_stat(path, module_name, |stat| stat.tested += 1);
     }
 
     /// Increments the number of mutants killed for the given path.
     /// If the path is not in the report, it adds it with the number of mutants tested and killed
     /// set to the default (0) and then increases only killed count!
-    pub fn increment_mutants_killed(&mut self, path: &PathBuf) {
-        let entry = self
-            .files
-            .entry(path.clone())
-            .or_insert(MutantStats::default());
-        entry.killed += 1;
+    pub fn increment_mutants_killed(&mut self, path: &Path, module_name: &str) {
+        self.increment_stat(path, module_name, |stat| stat.killed += 1);
     }
 
     /// Returns the number of mutants tested.
     pub fn mutants_tested(&self) -> u64 {
-        self.files.values().map(|entry| entry.tested).sum()
+        self.total_count(|v| v.tested)
     }
 
     /// Returns the number of mutants killed.
     pub fn mutants_killed(&self) -> u64 {
-        self.files.values().map(|entry| entry.killed).sum()
+        self.total_count(|v| v.killed)
     }
 
     /// Save the report to a JSON file.
@@ -60,43 +52,60 @@ impl Report {
 
     /// Prints the report to stdout in a table format.
     pub fn print_table(&self) {
-        let mut builder = Builder::new();
+        for (path, stats) in &self.files {
+            println!("Statistics for file: {}", path.to_string_lossy());
 
-        builder.push_record(["File", "Mutants tested", "Mutants killed", "Percentage"]);
+            let mut builder = Builder::new();
+            builder.push_record(["Module", "Mutants tested", "Mutants killed", "Percentage"]);
 
-        for (path, stats) in self.files.iter() {
-            builder.push_record([
-                path.to_string_lossy().to_string(),
-                stats.tested.to_string(),
-                stats.killed.to_string(),
-                format!(
-                    "{:.2}%",
-                    (stats.killed as f64 / stats.tested as f64) * 100.0
-                ),
-            ]);
+            for stat in stats {
+                builder.push_record([
+                    stat.module.clone(),
+                    stat.tested.to_string(),
+                    stat.killed.to_string(),
+                    format!("{:.2}%", (stat.killed as f64 / stat.tested as f64) * 100.0),
+                ]);
+            }
+
+            let table = builder.build().with(Style::modern_rounded()).to_string();
+
+            println!("{table}\n\n");
         }
+    }
 
-        let table = builder.build().with(Style::modern_rounded()).to_string();
+    // Internal function to increment the chosen stat.
+    fn increment_stat<F>(&mut self, path: &Path, module_name: &str, mut increment: F)
+    where
+        F: FnMut(&mut MutantStats),
+    {
+        let entry = self
+            .files
+            .entry(path.to_path_buf())
+            .or_insert(vec![MutantStats::new(module_name)]);
 
-        println!("{}", table);
+        match entry.iter_mut().find(|s| s.module == module_name) {
+            Some(stat) => increment(stat),
+            None => {
+                entry.push(MutantStats::new(module_name));
+            },
+        }
+    }
+
+    // Internal function to count the chosen stat.
+    fn total_count<F>(&self, mut count: F) -> u64
+    where
+        F: FnMut(&MutantStats) -> u64,
+    {
+        self.files
+            .values()
+            .map(|entry| entry.iter().map(&mut count).sum::<u64>())
+            .sum()
     }
 
     /// Returns the list of entries in the report.
     #[cfg(test)]
-    pub fn entries(&self) -> &HashMap<PathBuf, MutantStats> {
+    pub fn entries(&self) -> &HashMap<PathBuf, Vec<MutantStats>> {
         &self.files
-    }
-
-    /// Adds an entry to the report.
-    #[cfg(test)]
-    fn add_entry(&mut self, path: PathBuf, entry: MutantStats) {
-        self.files.insert(path, entry);
-    }
-
-    /// Returns `true` if the report contains an entry for the given path.
-    #[cfg(test)]
-    fn contains(&self, path: &PathBuf) -> bool {
-        self.files.contains_key(path)
     }
 }
 
@@ -104,10 +113,23 @@ impl Report {
 /// It contains the number of mutants tested and killed.
 #[derive(Default, Debug, Serialize)]
 pub struct MutantStats {
+    /// Module name.
+    pub module: String,
     /// The number of mutants tested.
     pub tested: u64,
     /// The number of mutants killed.
     pub killed: u64,
+}
+
+impl MutantStats {
+    /// Creates a new entry with the given number of mutants tested and killed.
+    pub fn new(module: &str) -> Self {
+        Self {
+            module: module.to_string(),
+            tested: 0,
+            killed: 0,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -122,70 +144,69 @@ mod tests {
     }
 
     #[test]
-    fn adding_entry_increases_count() {
+    fn increment_mutants_tested_adds_new_module_if_not_present() {
         let mut report = Report::new();
         let path = PathBuf::from("path/to/file");
-        let stats = MutantStats {
-            tested: 5,
-            killed: 3,
-        };
-        report.add_entry(path, stats);
-        assert_eq!(report.entries().len(), 1);
+        let module_name = "new_module";
+        report.increment_mutants_tested(&path, module_name);
+        let entry = report.entries().get(&path).unwrap();
+        assert!(entry.iter().any(|s| s.module == module_name));
     }
 
     #[test]
-    fn contains_returns_true_for_existing_entry() {
+    fn increment_mutants_killed_adds_new_module_if_not_present() {
         let mut report = Report::new();
         let path = PathBuf::from("path/to/file");
-        let stats = MutantStats {
-            tested: 5,
-            killed: 3,
-        };
-        report.add_entry(path.clone(), stats);
-        assert!(report.contains(&path));
+        let module_name = "new_module";
+        report.increment_mutants_killed(&path, module_name);
+        let entry = report.entries().get(&path).unwrap();
+        assert!(entry.iter().any(|s| s.module == module_name));
     }
 
     #[test]
-    fn contains_returns_false_for_non_existing_entry() {
-        let report = Report::new();
-        let path = PathBuf::from("path/to/file");
-        assert!(!report.contains(&path));
-    }
-
-    #[test]
-    fn increment_mutants_tested_increases_tested_count() {
+    fn increment_mutants_tested_increases_tested_count_for_existing_module() {
         let mut report = Report::new();
         let path = PathBuf::from("path/to/file");
-        report.increment_mutants_tested(&path);
-        assert_eq!(report.entries().get(&path).unwrap().tested, 1);
+        let module_name = "existing_module";
+        report.increment_mutants_tested(&path, module_name);
+        report.increment_mutants_tested(&path, module_name);
+        let entry = report.entries().get(&path).unwrap();
+        let stat = entry.iter().find(|s| s.module == module_name).unwrap();
+        assert_eq!(stat.tested, 2);
     }
 
     #[test]
-    fn increment_mutants_killed_increases_killed_count() {
+    fn increment_mutants_killed_increases_killed_count_for_existing_module() {
         let mut report = Report::new();
         let path = PathBuf::from("path/to/file");
-        report.increment_mutants_killed(&path);
-        assert_eq!(report.entries().get(&path).unwrap().killed, 1);
+        let module_name = "existing_module";
+        report.increment_mutants_killed(&path, module_name);
+        report.increment_mutants_killed(&path, module_name);
+        let entry = report.entries().get(&path).unwrap();
+        let stat = entry.iter().find(|s| s.module == module_name).unwrap();
+        assert_eq!(stat.killed, 2);
     }
 
     #[test]
-    fn mutants_tested_returns_total_tested_count() {
+    fn mutants_tested_returns_correct_total_tested_count() {
         let mut report = Report::new();
         let path1 = PathBuf::from("path/to/file1");
         let path2 = PathBuf::from("path/to/file2");
-        report.increment_mutants_tested(&path1);
-        report.increment_mutants_tested(&path2);
+        let module_name = "module";
+        report.increment_mutants_tested(&path1, module_name);
+        report.increment_mutants_tested(&path2, module_name);
         assert_eq!(report.mutants_tested(), 2);
         assert_eq!(report.mutants_killed(), 0);
     }
 
     #[test]
-    fn mutants_killed_returns_total_killed_count() {
+    fn mutants_killed_returns_correct_total_killed_count() {
         let mut report = Report::new();
         let path1 = PathBuf::from("path/to/file1");
         let path2 = PathBuf::from("path/to/file2");
-        report.increment_mutants_killed(&path1);
-        report.increment_mutants_killed(&path2);
+        let module_name = "module";
+        report.increment_mutants_killed(&path1, module_name);
+        report.increment_mutants_killed(&path2, module_name);
         assert_eq!(report.mutants_killed(), 2);
         assert_eq!(report.mutants_tested(), 0);
     }


### PR DESCRIPTION
### Description
This PR introduces several minor features.

1.     Move Mutator now adds one additional field to the report, with the module name.
2.     Move Mutator won't accept anymore file filters - there is now module filter.
3.     Move Mutator accepts function names to be checked for individual files.
4.     Downsampling has been added.
5.     Move Specification Tester reports have been refactored and now they are granular on the module level.
6.     Minor refactors.

Downsampling note: initially, downsampling was designed to use random filter to reduce mutants amount. But, during my tests I've noticed that it may lead to the case when some of the files or modules couldn't be tested at all, especially when they had one or two possible mutations. To avoid that, I've introduced a ratio which deletes mutants more regular and keeps some rules like not deleting mutation when it's the only one from the file etc.

### Test Plan
Unit tests has been updated to reflect all the refactoring changes.