### PR TITLE
[move-mutator] break/continue replacement operator

### DIFF
--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use crate::mutant::Mutant;
 use crate::operator::MutationOp;
 use crate::operators::binary::Binary;
+use crate::operators::break_continue::BreakContinue;
 use crate::operators::unary::Unary;
 
 /// Traverses the AST, identifies places where mutation operators can be applied
@@ -226,6 +227,11 @@ fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
             mutants.extend(parse_expression_and_find_mutants(*exp)?);
             Ok(mutants)
         },
+        ast::Exp_::Break | ast::Exp_::Continue => {
+            let mut mutants = vec![];
+            mutants.push(Mutant::new(MutationOp::BreakContinue(BreakContinue::new(exp)), None));
+            Ok(mutants)
+        },
         ast::Exp_::Abort(exp)
         | ast::Exp_::Annotate(exp, _)
         | ast::Exp_::Borrow(_, exp)
@@ -240,8 +246,6 @@ fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
         | ast::Exp_::Copy(_)
         | ast::Exp_::Name(_, _)
         | ast::Exp_::Unit
-        | ast::Exp_::Break
-        | ast::Exp_::Continue
         | ast::Exp_::Spec(_)
         | ast::Exp_::Index(_, _)
         | ast::Exp_::UnresolvedError

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -76,9 +76,9 @@ impl MutationOperator for MutationOp {
 impl fmt::Display for MutationOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            MutationOp::BinaryOp(bin_op) => write!(f, "{}", bin_op),
-            MutationOp::UnaryOp(unary_op) => write!(f, "{}", unary_op),
-            MutationOp::BreakContinue(break_continue) => write!(f, "{}", break_continue),
+            MutationOp::BinaryOp(bin_op) => write!(f, "{bin_op}"),
+            MutationOp::UnaryOp(unary_op) => write!(f, "{unary_op}"),
+            MutationOp::BreakContinue(break_continue) => write!(f, "{break_continue}"),
         }
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/break_continue.rs
+++ b/third_party/move/tools/move-mutator/src/operators/break_continue.rs
@@ -14,6 +14,8 @@ pub struct BreakContinue {
 }
 
 impl BreakContinue {
+    /// Creates a new instance of the break/continue mutation operator.
+    #[must_use]
     pub fn new(operation: ast::Exp) -> Self {
         Self { operation }
     }

--- a/third_party/move/tools/move-mutator/src/operators/break_continue.rs
+++ b/third_party/move/tools/move-mutator/src/operators/break_continue.rs
@@ -1,0 +1,126 @@
+use crate::operator::{MutantInfo, MutationOperator};
+use crate::report::{Mutation, Range};
+use move_command_line_common::files::FileHash;
+use move_compiler::parser::ast;
+use move_compiler::parser::ast::Exp_;
+use std::fmt;
+use std::fmt::Debug;
+
+/// Break and continue mutation operator.
+/// Replaces break and continue statements with each other or deletes them.
+#[derive(Debug, Clone)]
+pub struct BreakContinue {
+    operation: ast::Exp,
+}
+
+impl BreakContinue {
+    pub fn new(operation: ast::Exp) -> Self {
+        Self { operation }
+    }
+}
+
+impl MutationOperator for BreakContinue {
+    fn apply(&self, source: &str) -> Vec<MutantInfo> {
+        let start = self.operation.loc.start() as usize;
+        let end = self.operation.loc.end() as usize;
+        let cur_op = &source[start..end];
+
+        // Group of exchangeable binary operators - we only want to replace the operator with a different one
+        // within the same group.
+        let ops: Vec<&str> = match self.operation.value {
+            Exp_::Break => {
+                vec!["continue", "{}"]
+            },
+            Exp_::Continue => {
+                vec!["break", "{}"]
+            },
+            _ => vec![],
+        };
+
+        ops.into_iter()
+            .map(|op| {
+                let mut mutated_source = source.to_string();
+                mutated_source.replace_range(start..end, op);
+                MutantInfo::new(
+                    mutated_source,
+                    Mutation::new(
+                        Range::new(start, end),
+                        "break_continue_replacement".to_string(),
+                        cur_op.to_string(),
+                        op.to_string(),
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn get_file_hash(&self) -> FileHash {
+        self.operation.loc.file_hash()
+    }
+}
+
+impl fmt::Display for BreakContinue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "BreakContinueOperator({:?}, location: file hash: {}, index start: {}, index stop: {})",
+            self.operation.value,
+            self.operation.loc.file_hash(),
+            self.operation.loc.start(),
+            self.operation.loc.end()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_command_line_common::files::FileHash;
+    use move_compiler::parser::ast::Exp;
+    use move_ir_types::location::Loc;
+
+    #[test]
+    fn test_apply_break() {
+        let loc = Loc::new(FileHash::new(""), 0, 5);
+        let exp = Exp {
+            value: Exp_::Break,
+            loc,
+        };
+        let operator = BreakContinue::new(exp);
+        let source = "break";
+        let expected = vec!["continue", "{}"];
+        let result = operator.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
+    }
+
+    #[test]
+    fn test_apply_continue() {
+        let loc = Loc::new(FileHash::new(""), 0, 8);
+        let exp = Exp {
+            value: Exp_::Continue,
+            loc,
+        };
+        let operator = BreakContinue::new(exp);
+        let source = "continue";
+        let expected = vec!["break", "{}"];
+        let result = operator.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
+    }
+
+    #[test]
+    fn test_get_file_hash() {
+        let loc = Loc::new(FileHash::new(""), 0, 0);
+        let exp = Exp {
+            value: Exp_::Break,
+            loc,
+        };
+        let operator = BreakContinue::new(exp);
+        assert_eq!(operator.get_file_hash(), FileHash::new(""));
+    }
+}

--- a/third_party/move/tools/move-mutator/src/operators/mod.rs
+++ b/third_party/move/tools/move-mutator/src/operators/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod binary;
+pub(crate) mod break_continue;
 pub(crate) mod unary;

--- a/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "breakcontinue"
+version = "0.0.0"
+
+[addresses]
+TestAccount = "0xCAFE"

--- a/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/sources/Break.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/sources/Break.move
@@ -1,0 +1,12 @@
+module TestAccount::Break {
+    fun smallest_factor(n: u64): u64 {
+        // assuming the input is not 0 or 1
+        let i = 2;
+        while (i <= n) {
+            if (n % i == 0) break;
+            i = i + 1
+        };
+
+        i
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/sources/BreakContinue.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/sources/BreakContinue.move
@@ -1,0 +1,14 @@
+module TestAccount::BreakContinue {
+    fun sum_intermediate(n: u64): u64 {
+        let sum = 0;
+        let i = 0;
+        loop {
+            i = i + 1;
+            if (i % 10 == 0) continue;
+            if (i > n) break;
+            sum = sum + i
+        };
+
+        sum
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/sources/Continue.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/breakcontinue/sources/Continue.move
@@ -1,0 +1,13 @@
+module TestAccount::Continue {
+    fun sum_intermediate(n: u64): u64 {
+        let sum = 0;
+        let i = 0;
+        while (i < n) {
+            i = i + 1;
+            if (i % 10 == 0) continue;
+            sum = sum + i;
+        };
+
+        sum
+    }
+}


### PR DESCRIPTION
### Description

This PR adds new mutation operator - break/continue replacement.

This operator replaces break and continue operators with each other or with the empty statement `{ }`.

### Test Plan
Unit tests added to the new operator module.
New test asset added to tests exactly `breakcontinue` operator.
