### PR TITLE
[move-mutator] prepare deps and resolve names during AST generation

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -16,6 +16,8 @@ rust-version.workspace = true
 anyhow = "1.0"
 clap = { version = "4.3", features = ["derive"] }
 diffy = "0.3"
+either = "1.9"
+itertools = "0.12"
 log = "0.4"
 pretty_env_logger = "0.5"
 rand = "0.8"
@@ -28,3 +30,4 @@ move-command-line-common = { path = "../../move-command-line-common" }
 move-compiler = { path = "../../move-compiler" }
 move-ir-types = { path = "../../move-ir/types" }
 move-package = { path = "../move-package" }
+move-symbol-pool = { path = "../../move-symbol-pool" }

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -60,7 +60,7 @@ pub fn generate_ast(
         .map(|p| p.to_str().expect("source path contains invalid characters"))
         .collect::<Vec<_>>();
 
-    // If -m option is specified we should use only `move_sources`. Using Move source means we won't
+    // If the `-m` option is specified, we should use only `move_sources`. Using Move source means we won't
     // check for deps or resolve names as there might be no standard package layout. That means we can mutate
     // only quite simple files.
     let compiler = if source_files.is_empty() {
@@ -74,7 +74,7 @@ pub fn generate_ast(
     let (_, stepped) = unwrap_or_report_diagnostics(&files, res);
     let (_, ast) = stepped.into_ast();
 
-    trace!("Sources parsed successfully, AST generated.");
+    trace!("Sources parsed successfully, AST generated");
 
     Ok((files, ast))
 }
@@ -82,6 +82,8 @@ pub fn generate_ast(
 /// Prepare the compiler for the given package.
 /// This function prepares the compiler for the given package - it resolves all names and dependencies reading them
 /// from the manifest file present at the package root.
+///
+/// This function is mostly copy of the code present in the `move_package` crate (build_all).
 ///
 /// # Arguments
 ///

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -13,6 +13,8 @@ pub struct Mutant {
 
 impl Mutant {
     /// Creates a new mutant.
+    /// `module_name` argument is optional as during the mutant creation the code may not know the module name uet.
+    /// It can be set later using `set_module_name` method.
     pub fn new(operator: MutationOp, module_name: Option<ModuleName>) -> Self {
         Self {
             operator,

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -70,7 +70,7 @@ fn traverse_module_with_check(
     {
         trace!(
             "Skipping module {} as it does not come from source project",
-            filename_path.to_str().unwrap()
+            filename
         );
         return Ok(vec![]);
     }

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -1035,7 +1035,7 @@ pub(crate) fn apply_named_address_renaming(
         .collect()
 }
 
-pub(crate) fn make_source_and_deps_for_compiler(
+pub fn make_source_and_deps_for_compiler(
     resolution_graph: &ResolvedGraph,
     root: &ResolvedPackage,
     deps: Vec<(


### PR DESCRIPTION
### Description

When AST is generated from the `typing` module there is a need to resolve all the deps and names for the compiler to operate properly. `typing` is the fourth stage so it means that source code must pass through parser, expansion and naming modules before.

This PR introduces proper compiler preparation for packages and plain Move files.

