### PR TITLE
[move-mutator] if/else and delete operators (w/ some fixes)

### DIFF
--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -4,22 +4,6 @@
 
 The Move mutator is a tool that mutates Move source code. It can be used to help test the robustness of Move specifications and unit tests by generating different code versions (mutants).
 
-## Prototype
-This chapter will be deleted upon implementing the Move mutator tool.
-
-The Prototype implements only binary operator replacement (arithmetic, bitwise and shifts) and unary operator replacement. Command line options mainly handle source file paths (single or package).
-
-Mutants are currently stored in the `mutants_output` directory, and there is no way to change it. Mutants are just saved in a flat structure (no subdirectories). Each mutant filename consists of the original source filename with the next index appended.
-
-The report is generated on screen and lists all generated mutants (which mutation operator was used, location in the original source file, and mutant output). It's not possible to create the report in a file.
-
-Not supported:
-- configuration file,
-- generating reports,
-- nicely formatted output,
-- mutant files output structure,
-- other mutation operators than binary and unary operator replacement.
-
 ### What's missing in the Move ecosystem
 
 To create a prototype, we've used existing Move tools and libraries. We've produced a working prototype, so generally, there are no significant gaps in the Move ecosystem. It's sufficient for the mutant generation.
@@ -239,10 +223,6 @@ The operator tests the conditions in the specifications and test suites.
 
 Thanks to the fact that, the operator is replaced with space instead of just removing.
 
-### Type replacement
-
-This mutation operator replaces types with other types. For example, the `u8` type can be replaced with the `u64` type.
-
 ### Literal replacement
 
 This mutation operator replaces literals with other literals. For example, the `0` literal can be replaced with the `1` literal or other random literal, `true` to `false`, etc.
@@ -254,12 +234,6 @@ The operator tests the different conditions in the specifications (like invarian
 ### Address replacement
 
 This mutation operator replaces addresses with other addresses. For example, the `0x1`/`@std` address can be replaced with the `0x000A` address or another random address.
-
-### Return value replacement
-
-This mutation operator replaces return values with other return values. For example, the concrete expressions can be replaced with concrete literals or other random literals.
-
-The operator tests the conditions in the test suites and, e.g. the `ensures` statement in specifications.
 
 ### Break/continue replacement or deletion
 

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -225,19 +225,25 @@ Thanks to the fact that, the operator is replaced with space instead of just rem
 
 ### Literal replacement
 
-This mutation operator replaces literals with other literals. For example, the `0` literal can be replaced with the `1` literal or other random literal, `true` to `false`, etc.
+This mutation operator replaces literals with other literals. For example, the `0` literal can be replaced with the `1` literal or other random literal, `true` to `false`, etc. This mutation operator can replaces also addresses with other addresses.
 
 It's possible to choose the type of the literal to be replaced. For example, it's possible to replace only boolean literals.
 
 The operator tests the different conditions in the specifications (like invariants) and test suites.
 
-### Address replacement
-
-This mutation operator replaces addresses with other addresses. For example, the `0x1`/`@std` address can be replaced with the `0x000A` address or another random address.
-
 ### Break/continue replacement or deletion
 
 This mutation operator replaces or deletes break/continue statements with other break/continue statements.
+
+### If/else replacement
+
+This mutation operator replaces if/else expression with constant boolean values. For example, the `if (cond) { ... } else { ... }` expression can be replaced with the `if (false) { ... } else { ... }` expression.
+
+### Delete statement operator
+
+This mutation operator deletes statements. It can be used to delete any statement in the source code that wouldn't affect the compilation process.
+
+Currently, it's used to delete `move_to` expressions to check if moving resources is verified properly.
 
 ## Extending the Move mutator tool
 

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -22,8 +22,8 @@ pub struct CLIOptions {
     #[clap(long, default_value = "false")]
     pub verify_mutants: bool,
     /// Indicates if the output files should be overwritten.
-    #[clap(long, short)]
-    pub no_overwrite: Option<bool>,
+    #[clap(long, short, default_value = "false")]
+    pub no_overwrite: bool,
     /// Name of the filter to use for downsampling. Downsampling reduces the amount of mutants to the desired amount.
     #[clap(long, hide = true)]
     pub downsample_filter: Option<String>,
@@ -45,7 +45,7 @@ impl Default for CLIOptions {
             mutate_modules: ModuleFilter::All,
             out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: false,
-            no_overwrite: None,
+            no_overwrite: false,
             downsample_filter: None,
             downsampling_ratio_percentage: None,
             configuration_file: None,

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -44,7 +44,7 @@ impl Default for CLIOptions {
             move_sources: vec![],
             mutate_modules: ModuleFilter::All,
             out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
-            verify_mutants: true,
+            verify_mutants: false,
             no_overwrite: None,
             downsample_filter: None,
             downsampling_ratio_percentage: None,

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -117,8 +117,7 @@ pub fn run_move_mutator(
 
                 info!("{} written to {}", mutant, mutant_path.display());
 
-                let mod_name = if let Some(module) = mutant.get_module_name() {
-                    let ModuleName(name) = module;
+                let mod_name = if let Some(ModuleName(name)) = mutant.get_module_name() {
                     name.value.to_string()
                 } else {
                     "script".to_owned() // if there is no module name, it is a script

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -22,9 +22,9 @@ use std::path::Path;
 
 use crate::configuration::Configuration;
 use crate::report::Report;
+use move_compiler::parser::ast::ModuleName;
 use move_package::BuildConfig;
 use std::path::PathBuf;
-use move_compiler::parser::ast::ModuleName;
 
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.
@@ -121,7 +121,7 @@ pub fn run_move_mutator(
                     let ModuleName(name) = module;
                     name.value.to_string()
                 } else {
-                    "script".to_owned()     // if there is no module name, it is a script
+                    "script".to_owned() // if there is no module name, it is a script
                 };
 
                 let mut entry = report::MutationReport::new(

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -63,7 +63,7 @@ fn traverse_module_with_check(
     let (filename, _) = files.get(&ident.loc.file_hash()).unwrap(); // File must exist inside the hashmap so it's safe to unwrap.
     let filename_path = Path::new(filename.as_str());
 
-    if conf.project.move_sources.len() > 0
+    if !conf.project.move_sources.is_empty()
         && !conf
             .project
             .move_sources
@@ -74,10 +74,11 @@ fn traverse_module_with_check(
             filename
         );
         return Ok(vec![]);
-    } else {
+    } else if conf.project.move_sources.is_empty() {
         let test_root = SourcePackageLayout::try_find_root(&filename_path.canonicalize()?)?;
         if let Some(project_path) = &conf.project_path {
-            if !test_root.ends_with(project_path) {
+            let project_path = project_path.canonicalize()?;
+            if test_root != project_path {
                 trace!(
                     "Skipping module: \n {} \n root: {} \n as it does not come from source project {}",
                     filename_path.to_string_lossy(), test_root.to_string_lossy(),

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -74,7 +74,9 @@ fn traverse_module_with_check(
             filename
         );
         return Ok(vec![]);
-    } else if conf.project.move_sources.is_empty() {
+    }
+
+    if conf.project.move_sources.is_empty() {
         let test_root = SourcePackageLayout::try_find_root(&filename_path.canonicalize()?)?;
         if let Some(project_path) = &conf.project_path {
             let project_path = project_path.canonicalize()?;

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -14,6 +14,7 @@ use crate::mutant::Mutant;
 use crate::operator::MutationOp;
 use crate::operators::binary::Binary;
 use crate::operators::break_continue::BreakContinue;
+use crate::operators::ifelse::IfElse;
 use crate::operators::literal::Literal;
 use crate::operators::unary::Unary;
 
@@ -230,7 +231,7 @@ fn parse_expressions(exp: Vec<Exp>) -> anyhow::Result<Vec<Mutant>> {
 /// When Move language is extended with new expressions, this function needs to be updated to support them.
 fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
     trace!("Parsing expression {exp:?}");
-    match exp.exp.value {
+    match exp.clone().exp.value {
         ast::UnannotatedExp_::BinopExp(left, binop, _type, right) => {
             // Parse left and right side of the operator as they are expressions and may contain
             // another things to mutate.
@@ -285,6 +286,7 @@ fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
             let mut mutants = parse_expression_and_find_mutants(*exp1)?;
             mutants.extend(parse_expression_and_find_mutants(*exp2)?);
             mutants.extend(parse_expression_and_find_mutants(*exp3)?);
+            mutants.push(Mutant::new(MutationOp::IfElse(IfElse::new(exp)), None));
             Ok(mutants)
         },
         ast::UnannotatedExp_::Break | ast::UnannotatedExp_::Continue => Ok(vec![Mutant::new(

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,5 +1,6 @@
 use crate::operators::binary::Binary;
 use crate::operators::break_continue::BreakContinue;
+use crate::operators::delete_stmt::DeleteStmt;
 use crate::operators::ifelse::IfElse;
 use crate::operators::literal::Literal;
 use crate::operators::unary::Unary;
@@ -55,6 +56,7 @@ pub enum MutationOp {
     BreakContinue(BreakContinue),
     Literal(Literal),
     IfElse(IfElse),
+    DeleteStmt(DeleteStmt),
 }
 
 impl MutationOperator for MutationOp {
@@ -67,6 +69,7 @@ impl MutationOperator for MutationOp {
             MutationOp::BreakContinue(break_continue) => break_continue.apply(source),
             MutationOp::Literal(literal) => literal.apply(source),
             MutationOp::IfElse(if_else) => if_else.apply(source),
+            MutationOp::DeleteStmt(delete_stmt) => delete_stmt.apply(source),
         }
     }
 
@@ -77,6 +80,7 @@ impl MutationOperator for MutationOp {
             MutationOp::BreakContinue(break_continue) => break_continue.get_file_hash(),
             MutationOp::Literal(literal) => literal.get_file_hash(),
             MutationOp::IfElse(if_else) => if_else.get_file_hash(),
+            MutationOp::DeleteStmt(delete_stmt) => delete_stmt.get_file_hash(),
         }
     }
 }
@@ -89,6 +93,7 @@ impl fmt::Display for MutationOp {
             MutationOp::BreakContinue(break_continue) => write!(f, "{break_continue}"),
             MutationOp::Literal(literal) => write!(f, "{literal}"),
             MutationOp::IfElse(if_else) => write!(f, "{if_else}"),
+            MutationOp::DeleteStmt(delete_stmt) => write!(f, "{delete_stmt}"),
         }
     }
 }
@@ -97,9 +102,7 @@ impl fmt::Display for MutationOp {
 mod tests {
     use super::*;
     use move_command_line_common::files::FileHash;
-    use move_compiler::naming::ast::{Type, Type_};
-    use move_compiler::parser::ast::{BinOp, BinOp_, UnaryOp, UnaryOp_};
-    use move_compiler::typing::ast::{UnannotatedExp, UnannotatedExp_};
+    use move_compiler::parser::ast::{BinOp, BinOp_};
     use move_ir_types::location::Loc;
 
     #[test]
@@ -112,46 +115,6 @@ mod tests {
         let operator = MutationOp::BinaryOp(Binary::new(bin_op));
         let source = "*";
         let expected = vec!["+", "-", "/", "%"];
-        let result = operator.apply(source);
-        assert_eq!(result.len(), expected.len());
-        for (i, r) in result.iter().enumerate() {
-            assert_eq!(r.mutated_source, expected[i]);
-        }
-    }
-
-    #[test]
-    fn test_apply_unary_operator() {
-        let loc = Loc::new(FileHash::new(""), 0, 1);
-        let unary_op = UnaryOp {
-            value: UnaryOp_::Not,
-            loc,
-        };
-        let operator = MutationOp::UnaryOp(Unary::new(unary_op));
-        let source = "!";
-        let expected = vec![" "];
-        let result = operator.apply(source);
-        assert_eq!(result.len(), expected.len());
-        for (i, r) in result.iter().enumerate() {
-            assert_eq!(r.mutated_source, expected[i]);
-        }
-    }
-
-    #[test]
-    fn test_apply_break_continue_operator() {
-        let loc = Loc::new(FileHash::new(""), 0, 5);
-        let exp = move_compiler::typing::ast::Exp {
-            exp: UnannotatedExp {
-                value: UnannotatedExp_::Break,
-                loc,
-            },
-            ty: Type {
-                value: Type_::Anything,
-                loc,
-            },
-        };
-        let operator = MutationOp::BreakContinue(BreakContinue::new(exp));
-        let source = "break";
-        let expected = vec!["continue", "{}"];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -1,5 +1,6 @@
 use crate::operators::binary::Binary;
 use crate::operators::break_continue::BreakContinue;
+use crate::operators::ifelse::IfElse;
 use crate::operators::literal::Literal;
 use crate::operators::unary::Unary;
 use crate::report::Mutation;
@@ -53,6 +54,7 @@ pub enum MutationOp {
     UnaryOp(Unary),
     BreakContinue(BreakContinue),
     Literal(Literal),
+    IfElse(IfElse),
 }
 
 impl MutationOperator for MutationOp {
@@ -64,6 +66,7 @@ impl MutationOperator for MutationOp {
             MutationOp::UnaryOp(unary_op) => unary_op.apply(source),
             MutationOp::BreakContinue(break_continue) => break_continue.apply(source),
             MutationOp::Literal(literal) => literal.apply(source),
+            MutationOp::IfElse(if_else) => if_else.apply(source),
         }
     }
 
@@ -73,6 +76,7 @@ impl MutationOperator for MutationOp {
             MutationOp::UnaryOp(unary_op) => unary_op.get_file_hash(),
             MutationOp::BreakContinue(break_continue) => break_continue.get_file_hash(),
             MutationOp::Literal(literal) => literal.get_file_hash(),
+            MutationOp::IfElse(if_else) => if_else.get_file_hash(),
         }
     }
 }
@@ -84,6 +88,7 @@ impl fmt::Display for MutationOp {
             MutationOp::UnaryOp(unary_op) => write!(f, "{unary_op}"),
             MutationOp::BreakContinue(break_continue) => write!(f, "{break_continue}"),
             MutationOp::Literal(literal) => write!(f, "{literal}"),
+            MutationOp::IfElse(if_else) => write!(f, "{if_else}"),
         }
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/binary.rs
+++ b/third_party/move/tools/move-mutator/src/operators/binary.rs
@@ -34,7 +34,15 @@ impl MutationOperator for Binary {
             BinOp_::Shl | BinOp_::Shr => {
                 vec!["<<", ">>"]
             },
-            _ => vec![],
+            BinOp_::Or | BinOp_::And => {
+                vec!["||", "&&"]
+            },
+            BinOp_::Eq | BinOp_::Neq | BinOp_::Lt | BinOp_::Gt | BinOp_::Le | BinOp_::Ge => {
+                vec!["==", "!=", "<", ">", "<=", ">="]
+            },
+            BinOp_::Range | BinOp_::Iff | BinOp_::Implies => {
+                vec![]
+            },
         };
 
         ops.into_iter()

--- a/third_party/move/tools/move-mutator/src/operators/break_continue.rs
+++ b/third_party/move/tools/move-mutator/src/operators/break_continue.rs
@@ -1,4 +1,5 @@
 use crate::operator::{MutantInfo, MutationOperator};
+use crate::operators::{MOVE_BREAK, MOVE_CONTINUE, MOVE_EMPTY_STMT};
 use crate::report::{Mutation, Range};
 use move_command_line_common::files::FileHash;
 use move_compiler::typing::ast;
@@ -30,10 +31,10 @@ impl MutationOperator for BreakContinue {
         // Group of exchangeable break/continue statements.
         let ops: Vec<&str> = match self.operation.exp.value {
             UnannotatedExp_::Break => {
-                vec!["continue", "{}"]
+                vec![MOVE_CONTINUE, MOVE_EMPTY_STMT]
             },
             UnannotatedExp_::Continue => {
-                vec!["break", "{}"]
+                vec![MOVE_BREAK, MOVE_EMPTY_STMT]
             },
             _ => vec![],
         };
@@ -95,8 +96,8 @@ mod tests {
             },
         };
         let operator = BreakContinue::new(exp);
-        let source = "break";
-        let expected = vec!["continue", "{}"];
+        let source = MOVE_BREAK;
+        let expected = vec![MOVE_CONTINUE, MOVE_EMPTY_STMT];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {
@@ -118,8 +119,8 @@ mod tests {
             },
         };
         let operator = BreakContinue::new(exp);
-        let source = "continue";
-        let expected = vec!["break", "{}"];
+        let source = MOVE_CONTINUE;
+        let expected = vec![MOVE_BREAK, MOVE_EMPTY_STMT];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {

--- a/third_party/move/tools/move-mutator/src/operators/delete_stmt.rs
+++ b/third_party/move/tools/move-mutator/src/operators/delete_stmt.rs
@@ -1,0 +1,83 @@
+use crate::operator::{MutantInfo, MutationOperator};
+use crate::operators::MOVE_EMPTY_STMT;
+use crate::report::{Mutation, Range};
+use move_command_line_common::files::FileHash;
+use move_compiler::typing::ast;
+use move_compiler::typing::ast::BuiltinFunction_;
+use std::fmt;
+use std::fmt::Debug;
+
+/// Statement delete operator.
+/// Deletes statements which can be potentially deleted, still allowing the code to compile
+/// properly.
+#[derive(Debug, Clone)]
+pub struct DeleteStmt {
+    operation: ast::Exp,
+}
+
+impl DeleteStmt {
+    /// Creates a new instance of the delete mutation operator.
+    #[must_use]
+    pub fn new(operation: ast::Exp) -> Self {
+        Self { operation }
+    }
+}
+
+impl MutationOperator for DeleteStmt {
+    fn apply(&self, source: &str) -> Vec<MutantInfo> {
+        let (start, end) = match &self.operation.exp.value {
+            ast::UnannotatedExp_::Builtin(f, _) => {
+                match &f.value {
+                    // move_to can be changed to the empty statement as it does not return anything
+                    BuiltinFunction_::MoveTo(_) => (
+                        self.operation.exp.loc.start() as usize,
+                        self.operation.exp.loc.end() as usize,
+                    ),
+                    _ => {
+                        return vec![];
+                    },
+                }
+            },
+            _ => {
+                return vec![];
+            },
+        };
+
+        let cur_op = &source[start..end];
+
+        let ops: Vec<&str> = vec![MOVE_EMPTY_STMT];
+
+        ops.into_iter()
+            .map(|op| {
+                let mut mutated_source = source.to_string();
+                mutated_source.replace_range(start..end, op);
+                MutantInfo::new(
+                    mutated_source,
+                    Mutation::new(
+                        Range::new(start, end),
+                        "delete_stmt_replacement".to_string(),
+                        cur_op.to_string(),
+                        op.to_string(),
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn get_file_hash(&self) -> FileHash {
+        self.operation.exp.loc.file_hash()
+    }
+}
+
+impl fmt::Display for DeleteStmt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DeleteStmtOperator({:?}, location: file hash: {}, index start: {}, index stop: {})",
+            self.operation.exp.value,
+            self.operation.exp.loc.file_hash(),
+            self.operation.exp.loc.start(),
+            self.operation.exp.loc.end()
+        )
+    }
+}

--- a/third_party/move/tools/move-mutator/src/operators/ifelse.rs
+++ b/third_party/move/tools/move-mutator/src/operators/ifelse.rs
@@ -1,0 +1,155 @@
+use crate::operator::{MutantInfo, MutationOperator};
+use crate::report::{Mutation, Range};
+use move_command_line_common::files::FileHash;
+use move_compiler::typing::ast;
+use move_compiler::typing::ast::UnannotatedExp_;
+use std::fmt;
+use std::fmt::Debug;
+
+/// IfElse mutation operator.
+/// Replaces expressions under the if/else statements with literals.
+#[derive(Debug, Clone)]
+pub struct IfElse {
+    operation: ast::Exp,
+}
+
+impl IfElse {
+    /// Creates a new instance of the if/else mutation operator.
+    #[must_use]
+    pub fn new(operation: ast::Exp) -> Self {
+        Self { operation }
+    }
+}
+
+impl MutationOperator for IfElse {
+    fn apply(&self, source: &str) -> Vec<MutantInfo> {
+        let if_op = &self.operation.exp.value;
+
+        let (start, end, cur_op) = match if_op {
+            UnannotatedExp_::IfElse(if_exp, _, _) => {
+                let start = if_exp.exp.loc.start() as usize;
+                let end = if_exp.exp.loc.end() as usize;
+                let cur_op = &source[start..end];
+
+                (start, end, cur_op)
+            },
+            _ => panic!("IfElse operator called on non-if expression."), // That should never happen!
+        };
+
+        // Change if/else expression to true/false.
+        let ops: Vec<&str> = vec!["true", "false"];
+
+        ops.into_iter()
+            .map(|op| {
+                let mut mutated_source = source.to_string();
+                mutated_source.replace_range(start..end, op);
+                MutantInfo::new(
+                    mutated_source,
+                    Mutation::new(
+                        Range::new(start, end),
+                        "if_else_replacement".to_string(),
+                        cur_op.to_string(),
+                        op.to_string(),
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn get_file_hash(&self) -> FileHash {
+        self.operation.exp.loc.file_hash()
+    }
+}
+
+impl fmt::Display for IfElse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "IfElseOperator({:?}, location: file hash: {}, index start: {}, index stop: {})",
+            self.operation.exp.value,
+            self.operation.exp.loc.file_hash(),
+            self.operation.exp.loc.start(),
+            self.operation.exp.loc.end()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_command_line_common::files::FileHash;
+    use move_compiler::naming::ast::{Type, Type_};
+    use move_compiler::typing::ast::{Exp, UnannotatedExp, UnannotatedExp_};
+    use move_ir_types::location::Loc;
+
+    fn crate_exp(loc: Loc) -> ast::Exp {
+        Exp {
+            exp: UnannotatedExp {
+                value: UnannotatedExp_::IfElse(
+                    Box::new(Exp {
+                        exp: UnannotatedExp {
+                            value: UnannotatedExp_::Value(
+                                move_compiler::expansion::ast::Value::new(
+                                    loc,
+                                    move_compiler::expansion::ast::Value_::Bool(true),
+                                ),
+                            ),
+                            loc,
+                        },
+                        ty: Type {
+                            value: Type_::Anything,
+                            loc,
+                        },
+                    }),
+                    Box::new(Exp {
+                        exp: UnannotatedExp {
+                            value: UnannotatedExp_::Break,
+                            loc,
+                        },
+                        ty: Type {
+                            value: Type_::Anything,
+                            loc,
+                        },
+                    }),
+                    Box::new(Exp {
+                        exp: UnannotatedExp {
+                            value: UnannotatedExp_::Break,
+                            loc,
+                        },
+                        ty: Type {
+                            value: Type_::Anything,
+                            loc,
+                        },
+                    }),
+                ),
+                loc,
+            },
+            ty: Type {
+                value: Type_::Anything,
+                loc,
+            },
+        }
+    }
+
+    #[test]
+    fn test_apply_ifelse() {
+        let loc = Loc::new(FileHash::new(""), 4, 5);
+        let exp = crate_exp(loc);
+        let operator = IfElse::new(exp);
+        let source = "if (a) { }";
+        let expected = vec!["if (true) { }", "if (false) { }"];
+        let result = operator.apply(source);
+        assert_eq!(result.len(), expected.len());
+        for (i, r) in result.iter().enumerate() {
+            assert_eq!(r.mutated_source, expected[i]);
+        }
+    }
+
+    #[test]
+    fn test_get_file_hash() {
+        let loc = Loc::new(FileHash::new("1234567890"), 0, 5);
+        let exp = crate_exp(loc);
+        let operator = IfElse::new(exp);
+        assert_eq!(operator.get_file_hash(), FileHash::new("1234567890"));
+    }
+}

--- a/third_party/move/tools/move-mutator/src/operators/ifelse.rs
+++ b/third_party/move/tools/move-mutator/src/operators/ifelse.rs
@@ -37,12 +37,16 @@ impl MutationOperator for IfElse {
         };
 
         // Change if/else expression to true/false.
-        let ops: Vec<&str> = vec!["true", "false"];
+        let ops: Vec<String> = vec![
+            "true".to_owned(),
+            "false".to_owned(),
+            format!("!({})", cur_op),
+        ];
 
         ops.into_iter()
             .map(|op| {
                 let mut mutated_source = source.to_string();
-                mutated_source.replace_range(start..end, op);
+                mutated_source.replace_range(start..end, op.as_str());
                 MutantInfo::new(
                     mutated_source,
                     Mutation::new(

--- a/third_party/move/tools/move-mutator/src/operators/literal.rs
+++ b/third_party/move/tools/move-mutator/src/operators/literal.rs
@@ -1,4 +1,9 @@
 use crate::operator::{MutantInfo, MutationOperator};
+use crate::operators::{
+    MOVE_ADDR_MAX, MOVE_ADDR_ZERO, MOVE_FALSE, MOVE_MAX_INFERRED_NUM, MOVE_MAX_U128, MOVE_MAX_U16,
+    MOVE_MAX_U256, MOVE_MAX_U32, MOVE_MAX_U64, MOVE_MAX_U8, MOVE_TRUE, MOVE_ZERO, MOVE_ZERO_U128,
+    MOVE_ZERO_U16, MOVE_ZERO_U256, MOVE_ZERO_U32, MOVE_ZERO_U64, MOVE_ZERO_U8,
+};
 use crate::report::{Mutation, Range};
 use move_command_line_common::files::FileHash;
 use move_compiler::expansion::ast;
@@ -30,62 +35,59 @@ impl MutationOperator for Literal {
         // Group of literal statements for possible Value types.
         let ops: Vec<String> = match &self.operation.value {
             Value_::Address(_addr) => {
-                vec![
-                    "0x0".to_owned(),
-                    "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".to_owned(),
-                ]
+                vec![MOVE_ADDR_ZERO.to_owned(), MOVE_ADDR_MAX.to_owned()]
             },
             Value_::Bool(_bool_val) => {
-                vec!["true".to_owned(), "false".to_owned()]
+                vec![MOVE_TRUE.to_owned(), MOVE_FALSE.to_owned()]
             },
             Value_::Bytearray(_bytearray) => {
                 vec!["b\"121112\"".to_owned()]
             },
             Value_::U8(u8_val) => {
                 vec![
-                    "0u8".to_owned(),
-                    "255u8".to_owned(),
+                    MOVE_ZERO_U8.to_owned(),
+                    MOVE_MAX_U8.to_owned(),
                     u8_val.saturating_add(1).to_string(),
                     u8_val.saturating_sub(1).to_string(),
                 ]
             },
             Value_::U16(u16_val) => {
                 vec![
-                    "0u16".to_owned(),
-                    "65535u16".to_owned(),
+                    MOVE_ZERO_U16.to_owned(),
+                    MOVE_MAX_U16.to_owned(),
                     u16_val.saturating_add(1).to_string(),
                     u16_val.saturating_sub(1).to_string(),
                 ]
             },
             Value_::U32(u32_val) => {
                 vec![
-                    "0u32".to_owned(),
-                    "4294967295u32".to_owned(),
+                    MOVE_ZERO_U32.to_owned(),
+                    MOVE_MAX_U32.to_owned(),
                     u32_val.saturating_add(1).to_string(),
                     u32_val.saturating_sub(1).to_string(),
                 ]
             },
             Value_::U64(u64_val) => {
                 vec![
-                    "0u64".to_owned(),
-                    "18446744073709551615u64".to_owned(),
+                    MOVE_ZERO_U64.to_owned(),
+                    MOVE_MAX_U64.to_owned(),
                     u64_val.saturating_add(1).to_string(),
                     u64_val.saturating_sub(1).to_string(),
                 ]
             },
             Value_::U128(u128_val) => {
                 vec![
-                    "0u128".to_owned(),
-                    "340282366920938463463374607431768211455u128".to_owned(),
+                    MOVE_ZERO_U128.to_owned(),
+                    MOVE_MAX_U128.to_owned(),
                     u128_val.saturating_add(1).to_string(),
                     u128_val.saturating_sub(1).to_string(),
                 ]
             },
             Value_::U256(_u256_val) => {
-                vec!["0u256".to_owned(), "115792089237316195423570985008687907853269984665640564039457584007913129639935u256".to_owned()]
+                vec![MOVE_ZERO_U256.to_owned(), MOVE_MAX_U256.to_owned()]
             },
             Value_::InferredNum(_inferred_num) => {
-                vec!["0".to_owned(), "115792089237316195423570985008687907853269984665640564039457584007913129639935".to_owned()]
+                vec![MOVE_ZERO.to_owned(), MOVE_MAX_INFERRED_NUM.to_owned()]
             },
         };
 
@@ -141,7 +143,7 @@ mod tests {
         };
         let operator = Literal::new(val);
         let source = "51";
-        let expected = vec!["0u8", "255u8", "52", "50"];
+        let expected = vec![MOVE_ZERO_U8, MOVE_MAX_U8, "52", "50"];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {
@@ -158,7 +160,7 @@ mod tests {
         };
         let operator = Literal::new(val);
         let source = "963";
-        let expected = vec!["0u16", "65535u16", "964", "962"];
+        let expected = vec![MOVE_ZERO_U16, MOVE_MAX_U16, "964", "962"];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {
@@ -175,7 +177,7 @@ mod tests {
         };
         let operator = Literal::new(val);
         let source = "1000963";
-        let expected = vec!["0u32", "4294967295u32", "1000964", "1000962"];
+        let expected = vec![MOVE_ZERO_U32, MOVE_MAX_U32, "1000964", "1000962"];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {
@@ -192,12 +194,7 @@ mod tests {
         };
         let operator = Literal::new(val);
         let source = "963251000963";
-        let expected = vec![
-            "0u64",
-            "18446744073709551615u64",
-            "963251000964",
-            "963251000962",
-        ];
+        let expected = vec![MOVE_ZERO_U64, MOVE_MAX_U64, "963251000964", "963251000962"];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {
@@ -215,8 +212,8 @@ mod tests {
         let operator = Literal::new(val);
         let source = "123963251000963";
         let expected = vec![
-            "0u128",
-            "340282366920938463463374607431768211455u128",
+            MOVE_ZERO_U128,
+            MOVE_MAX_U128,
             "123963251000964",
             "123963251000962",
         ];
@@ -235,8 +232,8 @@ mod tests {
             loc,
         };
         let operator = Literal::new(val);
-        let source = "true";
-        let expected = vec!["false"];
+        let source = MOVE_TRUE;
+        let expected = vec![MOVE_FALSE];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {

--- a/third_party/move/tools/move-mutator/src/operators/literal.rs
+++ b/third_party/move/tools/move-mutator/src/operators/literal.rs
@@ -192,7 +192,12 @@ mod tests {
         };
         let operator = Literal::new(val);
         let source = "963251000963";
-        let expected = vec!["0u64", "18446744073709551615u64", "963251000964", "963251000962"];
+        let expected = vec![
+            "0u64",
+            "18446744073709551615u64",
+            "963251000964",
+            "963251000962",
+        ];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {
@@ -209,7 +214,12 @@ mod tests {
         };
         let operator = Literal::new(val);
         let source = "123963251000963";
-        let expected = vec!["0u128", "340282366920938463463374607431768211455u128", "123963251000964", "123963251000962"];
+        let expected = vec![
+            "0u128",
+            "340282366920938463463374607431768211455u128",
+            "123963251000964",
+            "123963251000962",
+        ];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {

--- a/third_party/move/tools/move-mutator/src/operators/mod.rs
+++ b/third_party/move/tools/move-mutator/src/operators/mod.rs
@@ -1,5 +1,32 @@
 pub(crate) mod binary;
 pub(crate) mod break_continue;
+pub(crate) mod delete_stmt;
 pub(crate) mod ifelse;
 pub(crate) mod literal;
 pub(crate) mod unary;
+
+// Section with Move constants.
+pub(crate) const MOVE_EMPTY_STMT: &str = "{}";
+pub(crate) const MOVE_CONTINUE: &str = "continue";
+pub(crate) const MOVE_BREAK: &str = "break";
+pub(crate) const MOVE_TRUE: &str = "true";
+pub(crate) const MOVE_FALSE: &str = "false";
+pub(crate) const MOVE_ZERO: &str = "0";
+pub(crate) const MOVE_ZERO_U8: &str = "0u8";
+pub(crate) const MOVE_ZERO_U16: &str = "0u16";
+pub(crate) const MOVE_ZERO_U32: &str = "0u32";
+pub(crate) const MOVE_ZERO_U64: &str = "0u64";
+pub(crate) const MOVE_ZERO_U128: &str = "0u128";
+pub(crate) const MOVE_ZERO_U256: &str = "0u256";
+pub(crate) const MOVE_MAX_U8: &str = "255u8";
+pub(crate) const MOVE_MAX_U16: &str = "65535u16";
+pub(crate) const MOVE_MAX_U32: &str = "4294967295u32";
+pub(crate) const MOVE_MAX_U64: &str = "18446744073709551615u64";
+pub(crate) const MOVE_MAX_U128: &str = "340282366920938463463374607431768211455u128";
+pub(crate) const MOVE_MAX_U256: &str =
+    "115792089237316195423570985008687907853269984665640564039457584007913129639935u256";
+pub(crate) const MOVE_MAX_INFERRED_NUM: &str =
+    "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+pub(crate) const MOVE_ADDR_ZERO: &str = "0x0";
+pub(crate) const MOVE_ADDR_MAX: &str =
+    "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";

--- a/third_party/move/tools/move-mutator/src/operators/mod.rs
+++ b/third_party/move/tools/move-mutator/src/operators/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod binary;
 pub(crate) mod break_continue;
+pub(crate) mod ifelse;
 pub(crate) mod literal;
 pub(crate) mod unary;

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -101,9 +101,9 @@ pub(crate) fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow:
     trace!("Trying to set up output directory to: {output_dir:?}");
 
     // Check if output directory exists and if it should be overwritten.
-    if output_dir.exists() && mutator_configuration.project.no_overwrite.unwrap_or(false) {
+    if output_dir.exists() && mutator_configuration.project.no_overwrite {
         return Err(anyhow::anyhow!(
-            "Output directory already exists. Use --no-overwrite=false to overwrite."
+            "Output directory already exists and --no-overwrite flag was used."
         ));
     }
 
@@ -196,7 +196,7 @@ mod tests {
         let output_dir = temp_dir.path().join("output");
         let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
-            no_overwrite: Some(false),
+            no_overwrite: false,
             ..Default::default()
         };
         let config = Configuration::new(options, None);
@@ -211,7 +211,7 @@ mod tests {
         fs::create_dir(&output_dir).unwrap();
         let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
-            no_overwrite: Some(false),
+            no_overwrite: false,
             ..Default::default()
         };
         let config = Configuration::new(options, None);
@@ -226,7 +226,7 @@ mod tests {
         fs::create_dir(&output_dir).unwrap();
         let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
-            no_overwrite: Some(true),
+            no_overwrite: true,
             ..Default::default()
         };
         let config = Configuration::new(options, None);

--- a/third_party/move/tools/move-mutator/tests/move-assets/basic_coin/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/basic_coin/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "basic_coin"
+version = "0.0.0"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+
+[addresses]
+std =  "0x1"
+CafeAccount = "0xCAFE"

--- a/third_party/move/tools/move-mutator/tests/move-assets/basic_coin/sources/BasicCoin.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/basic_coin/sources/BasicCoin.move
@@ -1,0 +1,68 @@
+/// This module defines a minimal Coin and Balance.
+module CafeAccount::BasicCoin {
+    use std::signer;
+
+    /// Address of the owner of this module
+    const MODULE_OWNER: address = @CafeAccount;
+
+    /// Error codes
+    const ENOT_MODULE_OWNER: u64 = 0;
+    const EINSUFFICIENT_BALANCE: u64 = 1;
+    const EALREADY_HAS_BALANCE: u64 = 2;
+
+    struct Coin has store {
+        value: u64
+    }
+
+    /// Struct representing the balance of each address.
+    struct Balance has key {
+        coin: Coin
+    }
+
+    /// Publish an empty balance resource under `account`'s address. This function must be called before
+    /// minting or transferring to the account.
+    /// Making this function entry allows to call it directly in the transactions
+    entry public fun publish_balance(account: &signer) {
+        let empty_coin = Coin { value: 0 };
+        assert!(!exists<Balance>(signer::address_of(account)), EALREADY_HAS_BALANCE);
+        move_to(account, Balance { coin: empty_coin });
+    }
+
+    /// Mint `amount` tokens to `mint_addr`. Mint must be approved by the module owner.
+    public fun mint(module_owner: &signer, mint_addr: address, amount: u64) acquires Balance {
+        // Only the owner of the module can initialize this module
+        assert!(signer::address_of(module_owner) == MODULE_OWNER, ENOT_MODULE_OWNER);
+
+        // Deposit `amount` of tokens to `mint_addr`'s balance
+        deposit(mint_addr, Coin { value: amount });
+    }
+
+    /// Returns the balance of `owner`.
+    public fun balance_of(owner: address): u64 acquires Balance {
+        borrow_global<Balance>(owner).coin.value
+    }
+
+    /// Transfers `amount` of tokens from `from` to `to`.
+    public fun transfer(from: &signer, to: address, amount: u64) acquires Balance {
+        let check = withdraw(signer::address_of(from), amount);
+        deposit(to, check);
+    }
+
+    /// Withdraw `amount` number of tokens from the balance under `addr`.
+    fun withdraw(addr: address, amount: u64) : Coin acquires Balance {
+        let balance = balance_of(addr);
+        // balance must be greater than the withdraw amount
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
+        let balance_ref = &mut borrow_global_mut<Balance>(addr).coin.value;
+        *balance_ref = balance - amount;
+        Coin { value: amount }
+    }
+
+    /// Deposit `amount` number of tokens to the balance under `addr`.
+    fun deposit(addr: address, check: Coin) acquires Balance {
+        let balance = balance_of(addr);
+        let balance_ref = &mut borrow_global_mut<Balance>(addr).coin.value;
+        let Coin { value } = check;
+        *balance_ref = balance + value;
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/basic_coin/sources/GetCoin.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/basic_coin/sources/GetCoin.move
@@ -1,0 +1,23 @@
+script {
+    use CafeAccount::BasicCoin;
+
+    fun publish_balance(s: signer) {
+        BasicCoin::publish_balance(&s);
+    }
+}
+
+script {
+    use CafeAccount::BasicCoin;
+
+    fun mint_some(module_owner: signer, rx_addr: address, amount: u64) {
+        BasicCoin::mint(&module_owner, rx_addr, amount);
+    }
+}
+
+script {
+    use CafeAccount::BasicCoin;
+
+    fun test(module_owner: signer, rx_addr: address, amount: u64) {
+        let amount2 = amount + 10;
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/conditional.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/conditional.move
@@ -1,0 +1,28 @@
+module Test::Cond {
+    fun main() {
+        let a = true;
+        if (a) {
+            let b = 10;
+        };
+    }
+
+    fun main2() {
+        let a = true;
+        if (a) {
+            let b = 10;
+        } else {
+            let c = 20;
+        };
+    }
+
+    fun main3() {
+        let a = true;
+        if (a) {
+            let b = 10;
+        } else if (a) {
+            let c = 20;
+        } else {
+            let d = 30;
+        };
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/move_to.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/move_to.move
@@ -1,0 +1,15 @@
+module 0x2::Collection {
+    struct Item has store {}
+
+    struct Collection has key {
+        item: Item
+    }
+
+    public fun start_collection(account: &signer) {
+        move_to<Collection>(account, Collection {
+            item: Item {}
+        });
+
+    }
+
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "p1"
+version = "0.0.0"
+
+[addresses]
+TestAccount = "0xCAFE2"

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/sources/Mul.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/sources/Mul.move
@@ -1,0 +1,10 @@
+module TestAccount::Mul {
+    public fun mul(x: u128, y: u128): u128 {
+        let mult = x * y;
+        spec {
+            assert mult == x*y;
+        };
+
+        mult
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "p2"
+version = "0.0.0"
+
+[dependencies]
+p1 = { local = "../p1" }
+
+[addresses]
+CafeAccount = "0xCAFE"
+TestAccount = "0xCAFE2"

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/sources/MulUse.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/sources/MulUse.move
@@ -1,0 +1,9 @@
+module CafeAccount::MulUse {
+    use TestAccount::Mul::mul;
+
+    fun mul_usage(x: u128, y: u128): u128 {
+        let z = x + 1;
+        let w = y + 2;
+        mul(z, w)
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
@@ -51,11 +51,11 @@ module TestAccount::Operators {
         !x
     }
 
-    fun eq(x: bool, y: bool): bool {
+    fun eq(x: u8, y: u8): bool {
         x == y
     }
 
-    fun neq(x: bool, y: bool): bool {
+    fun neq(x: u8, y: u8): bool {
         x != y
     }
 

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
@@ -39,6 +39,42 @@ module TestAccount::Operators {
         x >> y
     }
 
+    fun logical_or(x: bool, y: bool): bool {
+        x || y
+    }
+
+    fun logical_and(x: bool, y: bool): bool {
+        x && y
+    }
+
+    fun logical_not(x: bool): bool {
+        !x
+    }
+
+    fun eq(x: bool, y: bool): bool {
+        x == y
+    }
+
+    fun neq(x: bool, y: bool): bool {
+        x != y
+    }
+
+    fun lt(x: u64, y: u64): bool {
+        x < y
+    }
+
+    fun lte(x: u64, y: u64): bool {
+        x <= y
+    }
+
+    fun gt(x: u64, y: u64): bool {
+        x > y
+    }
+
+    fun gte(x: u64, y: u64): bool {
+        x >= y
+    }
+
     spec sum {
         ensures result == x+y;
     }
@@ -82,4 +118,37 @@ module TestAccount::Operators {
         aborts_if y >= 64;
         ensures result == x>>y;
     }
+
+    spec logical_or {
+        ensures result == x || y;
+    }
+
+    spec logical_not {
+        ensures result == !x;
+    }
+
+    spec eq {
+        ensures result == (x == y);
+    }
+
+    spec neq {
+        ensures result == (x != y);
+    }
+
+    spec lt {
+        ensures result == (x < y);
+    }
+
+    spec lte {
+        ensures result == (x <= y);
+    }
+
+    spec gt {
+        ensures result == (x > y);
+    }
+
+    spec gte {
+        ensures result == (x >= y);
+    }
+
 }


### PR DESCRIPTION
### Description

This PR introduces two new operators:
- if/else operator which replaces if expressions with constant bool values;
- delete statement operator which deletes some statements (currently `move_to`).

During the tests some things came out which are also addressed here as well as documentation has been slightly updated.
