### PR TITLE
[move-mutator] path rewriting, minor fixes and doc updates

### DIFF
--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -4,22 +4,6 @@
 
 The Move mutator is a tool that mutates Move source code. It can be used to help test the robustness of Move specifications and unit tests by generating different code versions (mutants).
 
-## Prototype
-This chapter will be deleted upon implementing the Move mutator tool.
-
-The Prototype implements only binary operator replacement (arithmetic, bitwise and shifts) and unary operator replacement. Command line options mainly handle source file paths (single or package).
-
-Mutants are currently stored in the `mutants_output` directory, and there is no way to change it. Mutants are just saved in a flat structure (no subdirectories). Each mutant filename consists of the original source filename with the next index appended.
-
-The report is generated on screen and lists all generated mutants (which mutation operator was used, location in the original source file, and mutant output). It's not possible to create the report in a file.
-
-Not supported:
-- configuration file,
-- generating reports,
-- nicely formatted output,
-- mutant files output structure,
-- other mutation operators than binary and unary operator replacement.
-
 ### What's missing in the Move ecosystem
 
 To create a prototype, we've used existing Move tools and libraries. We've produced a working prototype, so generally, there are no significant gaps in the Move ecosystem. It's sufficient for the mutant generation.
@@ -239,10 +223,6 @@ The operator tests the conditions in the specifications and test suites.
 
 Thanks to the fact that, the operator is replaced with space instead of just removing.
 
-### Type replacement
-
-This mutation operator replaces types with other types. For example, the `u8` type can be replaced with the `u64` type.
-
 ### Literal replacement
 
 This mutation operator replaces literals with other literals. For example, the `0` literal can be replaced with the `1` literal or other random literal, `true` to `false`, etc.
@@ -254,12 +234,6 @@ The operator tests the different conditions in the specifications (like invarian
 ### Address replacement
 
 This mutation operator replaces addresses with other addresses. For example, the `0x1`/`@std` address can be replaced with the `0x000A` address or another random address.
-
-### Return value replacement
-
-This mutation operator replaces return values with other return values. For example, the concrete expressions can be replaced with concrete literals or other random literals.
-
-The operator tests the conditions in the test suites and, e.g. the `ensures` statement in specifications.
 
 ### Break/continue replacement or deletion
 

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -225,19 +225,25 @@ Thanks to the fact that, the operator is replaced with space instead of just rem
 
 ### Literal replacement
 
-This mutation operator replaces literals with other literals. For example, the `0` literal can be replaced with the `1` literal or other random literal, `true` to `false`, etc.
+This mutation operator replaces literals with other literals. For example, the `0` literal can be replaced with the `1` literal or other random literal, `true` to `false`, etc. This mutation operator can replaces also addresses with other addresses.
 
 It's possible to choose the type of the literal to be replaced. For example, it's possible to replace only boolean literals.
 
 The operator tests the different conditions in the specifications (like invariants) and test suites.
 
-### Address replacement
-
-This mutation operator replaces addresses with other addresses. For example, the `0x1`/`@std` address can be replaced with the `0x000A` address or another random address.
-
 ### Break/continue replacement or deletion
 
 This mutation operator replaces or deletes break/continue statements with other break/continue statements.
+
+### If/else replacement
+
+This mutation operator replaces if/else expression with constant boolean values. For example, the `if (cond) { ... } else { ... }` expression can be replaced with the `if (false) { ... } else { ... }` expression.
+
+### Delete statement operator
+
+This mutation operator deletes statements. It can be used to delete any statement in the source code that wouldn't affect the compilation process.
+
+Currently, it's used to delete `move_to` expressions to check if moving resources is verified properly.
 
 ## Extending the Move mutator tool
 

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -22,8 +22,8 @@ pub struct CLIOptions {
     #[clap(long, default_value = "false")]
     pub verify_mutants: bool,
     /// Indicates if the output files should be overwritten.
-    #[clap(long, short)]
-    pub no_overwrite: Option<bool>,
+    #[clap(long, short, default_value = "false")]
+    pub no_overwrite: bool,
     /// Name of the filter to use for downsampling. Downsampling reduces the amount of mutants to the desired amount.
     #[clap(long, hide = true)]
     pub downsample_filter: Option<String>,
@@ -45,7 +45,7 @@ impl Default for CLIOptions {
             mutate_modules: ModuleFilter::All,
             out_mutant_dir: Some(PathBuf::from(DEFAULT_OUTPUT_DIR)),
             verify_mutants: false,
-            no_overwrite: None,
+            no_overwrite: false,
             downsample_filter: None,
             downsampling_ratio_percentage: None,
             configuration_file: None,

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -117,8 +117,7 @@ pub fn run_move_mutator(
 
                 info!("{} written to {}", mutant, mutant_path.display());
 
-                let mod_name = if let Some(module) = mutant.get_module_name() {
-                    let ModuleName(name) = module;
+                let mod_name = if let Some(ModuleName(name)) = mutant.get_module_name() {
                     name.value.to_string()
                 } else {
                     "script".to_owned() // if there is no module name, it is a script

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -63,7 +63,7 @@ fn traverse_module_with_check(
     let (filename, _) = files.get(&ident.loc.file_hash()).unwrap(); // File must exist inside the hashmap so it's safe to unwrap.
     let filename_path = Path::new(filename.as_str());
 
-    if conf.project.move_sources.len() > 0
+    if !conf.project.move_sources.is_empty()
         && !conf
             .project
             .move_sources
@@ -74,10 +74,11 @@ fn traverse_module_with_check(
             filename
         );
         return Ok(vec![]);
-    } else {
+    } else if conf.project.move_sources.is_empty() {
         let test_root = SourcePackageLayout::try_find_root(&filename_path.canonicalize()?)?;
         if let Some(project_path) = &conf.project_path {
-            if !test_root.ends_with(project_path) {
+            let project_path = project_path.canonicalize()?;
+            if test_root != project_path {
                 trace!(
                     "Skipping module: \n {} \n root: {} \n as it does not come from source project {}",
                     filename_path.to_string_lossy(), test_root.to_string_lossy(),

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -74,7 +74,9 @@ fn traverse_module_with_check(
             filename
         );
         return Ok(vec![]);
-    } else if conf.project.move_sources.is_empty() {
+    }
+
+    if conf.project.move_sources.is_empty() {
         let test_root = SourcePackageLayout::try_find_root(&filename_path.canonicalize()?)?;
         if let Some(project_path) = &conf.project_path {
             let project_path = project_path.canonicalize()?;

--- a/third_party/move/tools/move-mutator/src/operators/binary.rs
+++ b/third_party/move/tools/move-mutator/src/operators/binary.rs
@@ -34,7 +34,15 @@ impl MutationOperator for Binary {
             BinOp_::Shl | BinOp_::Shr => {
                 vec!["<<", ">>"]
             },
-            _ => vec![],
+            BinOp_::Or | BinOp_::And => {
+                vec!["||", "&&"]
+            },
+            BinOp_::Eq | BinOp_::Neq | BinOp_::Lt | BinOp_::Gt | BinOp_::Le | BinOp_::Ge => {
+                vec!["==", "!=", "<", ">", "<=", ">="]
+            },
+            BinOp_::Range | BinOp_::Iff | BinOp_::Implies => {
+                vec![]
+            },
         };
 
         ops.into_iter()

--- a/third_party/move/tools/move-mutator/src/operators/ifelse.rs
+++ b/third_party/move/tools/move-mutator/src/operators/ifelse.rs
@@ -37,12 +37,16 @@ impl MutationOperator for IfElse {
         };
 
         // Change if/else expression to true/false.
-        let ops: Vec<&str> = vec!["true", "false"];
+        let ops: Vec<String> = vec![
+            "true".to_owned(),
+            "false".to_owned(),
+            format!("!({})", cur_op),
+        ];
 
         ops.into_iter()
             .map(|op| {
                 let mut mutated_source = source.to_string();
-                mutated_source.replace_range(start..end, op);
+                mutated_source.replace_range(start..end, op.as_str());
                 MutantInfo::new(
                     mutated_source,
                     Mutation::new(

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -101,9 +101,9 @@ pub(crate) fn setup_output_dir(mutator_configuration: &Configuration) -> anyhow:
     trace!("Trying to set up output directory to: {output_dir:?}");
 
     // Check if output directory exists and if it should be overwritten.
-    if output_dir.exists() && mutator_configuration.project.no_overwrite.unwrap_or(false) {
+    if output_dir.exists() && mutator_configuration.project.no_overwrite {
         return Err(anyhow::anyhow!(
-            "Output directory already exists. Use --no-overwrite=false to overwrite."
+            "Output directory already exists and --no-overwrite flag was used."
         ));
     }
 
@@ -196,7 +196,7 @@ mod tests {
         let output_dir = temp_dir.path().join("output");
         let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
-            no_overwrite: Some(false),
+            no_overwrite: false,
             ..Default::default()
         };
         let config = Configuration::new(options, None);
@@ -211,7 +211,7 @@ mod tests {
         fs::create_dir(&output_dir).unwrap();
         let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
-            no_overwrite: Some(false),
+            no_overwrite: false,
             ..Default::default()
         };
         let config = Configuration::new(options, None);
@@ -226,7 +226,7 @@ mod tests {
         fs::create_dir(&output_dir).unwrap();
         let options = cli::CLIOptions {
             out_mutant_dir: Some(output_dir.clone()),
-            no_overwrite: Some(true),
+            no_overwrite: true,
             ..Default::default()
         };
         let config = Configuration::new(options, None);

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "p1"
+version = "0.0.0"
+
+[addresses]
+TestAccount = "0xCAFE2"

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/sources/Mul.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p1/sources/Mul.move
@@ -1,0 +1,10 @@
+module TestAccount::Mul {
+    public fun mul(x: u128, y: u128): u128 {
+        let mult = x * y;
+        spec {
+            assert mult == x*y;
+        };
+
+        mult
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "p2"
+version = "0.0.0"
+
+[dependencies]
+p1 = { local = "../p1" }
+
+[addresses]
+CafeAccount = "0xCAFE"
+TestAccount = "0xCAFE2"

--- a/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/sources/MulUse.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/relative_dep/p2/sources/MulUse.move
@@ -1,0 +1,9 @@
+module CafeAccount::MulUse {
+    use TestAccount::Mul::mul;
+
+    fun mul_usage(x: u128, y: u128): u128 {
+        let z = x + 1;
+        let w = y + 2;
+        mul(z, w)
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
@@ -51,11 +51,11 @@ module TestAccount::Operators {
         !x
     }
 
-    fun eq(x: bool, y: bool): bool {
+    fun eq(x: u8, y: u8): bool {
         x == y
     }
 
-    fun neq(x: bool, y: bool): bool {
+    fun neq(x: u8, y: u8): bool {
         x != y
     }
 

--- a/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Operators.move
@@ -39,6 +39,42 @@ module TestAccount::Operators {
         x >> y
     }
 
+    fun logical_or(x: bool, y: bool): bool {
+        x || y
+    }
+
+    fun logical_and(x: bool, y: bool): bool {
+        x && y
+    }
+
+    fun logical_not(x: bool): bool {
+        !x
+    }
+
+    fun eq(x: bool, y: bool): bool {
+        x == y
+    }
+
+    fun neq(x: bool, y: bool): bool {
+        x != y
+    }
+
+    fun lt(x: u64, y: u64): bool {
+        x < y
+    }
+
+    fun lte(x: u64, y: u64): bool {
+        x <= y
+    }
+
+    fun gt(x: u64, y: u64): bool {
+        x > y
+    }
+
+    fun gte(x: u64, y: u64): bool {
+        x >= y
+    }
+
     spec sum {
         ensures result == x+y;
     }
@@ -82,4 +118,37 @@ module TestAccount::Operators {
         aborts_if y >= 64;
         ensures result == x>>y;
     }
+
+    spec logical_or {
+        ensures result == x || y;
+    }
+
+    spec logical_not {
+        ensures result == !x;
+    }
+
+    spec eq {
+        ensures result == (x == y);
+    }
+
+    spec neq {
+        ensures result == (x != y);
+    }
+
+    spec lt {
+        ensures result == (x < y);
+    }
+
+    spec lte {
+        ensures result == (x <= y);
+    }
+
+    spec gt {
+        ensures result == (x > y);
+    }
+
+    spec gte {
+        ensures result == (x >= y);
+    }
+
 }


### PR DESCRIPTION
### Description

This PR contains mainly path rewriting issue solved and minor fixes to the code as well as documentation update.

List of things:
- local paths are now rewrited when mutant is copied to the temporary directory for verification - it's needed to solve the deps/naming by the compiler;
- `design.md` updates;
- binary operator updated to mutate almost all variants;
- simplified using `--no-overwrite` flag;
- minor code shortenings.

### Test Plan
New tests has been added to cover more usage cases.
Previous testcase should still work correctly.