### PR TITLE
[move-spec-test][move-mutator] diff exporting and cleaning path usage

### DIFF
--- a/third_party/move/tools/move-cli/src/base/spec_test.rs
+++ b/third_party/move/tools/move-cli/src/base/spec_test.rs
@@ -1,7 +1,6 @@
 use clap::*;
 use move_package::BuildConfig;
 use std::path::PathBuf;
-use crate::base::reroot_path;
 
 /// Test the Move specification using the Move Mutator and Move Prover
 #[derive(Parser)]
@@ -18,12 +17,12 @@ impl SpecTest {
     /// mutants are killed by the prover.
     /// If no path is provided, the current directory is used.
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
-        let rerooted_path = reroot_path(path)?;
+        let path = path.unwrap_or_else(|| PathBuf::from("."));
 
         let Self { options } = self;
 
         let options = options.unwrap_or_default();
 
-        move_spec_test::run_spec_test(&options, &config, &rerooted_path)
+        move_spec_test::run_spec_test(&options, &config, &path)
     }
 }

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -214,7 +214,7 @@ mod tests {
             Some(PathBuf::from("/path/to/output"))
         );
         assert_eq!(config.project.verify_mutants, true);
-        assert_eq!(config.project.no_overwrite.unwrap(), false);
+        assert_eq!(config.project.no_overwrite, false);
         assert_eq!(config.project.downsample_filter.unwrap(), "filter");
         assert_eq!(
             config.project.configuration_file.unwrap(),

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -24,7 +24,6 @@ use crate::configuration::Configuration;
 use crate::report::Report;
 use move_compiler::parser::ast::ModuleName;
 use move_package::BuildConfig;
-use std::path::PathBuf;
 
 /// Runs the Move mutator tool.
 /// Entry point for the Move mutator tool both for the CLI and the Rust API.
@@ -44,7 +43,7 @@ use std::path::PathBuf;
 pub fn run_move_mutator(
     options: cli::CLIOptions,
     config: &BuildConfig,
-    package_path: &PathBuf,
+    package_path: &Path,
 ) -> anyhow::Result<()> {
     // We need to initialize logger using try_init() as it might be already initialized in some other tool
     // (e.g. spec-test). If we use init() instead, we will get an abort.
@@ -57,7 +56,7 @@ pub fn run_move_mutator(
     // Load configuration from file or create a new one.
     let mutator_configuration = match options.configuration_file {
         Some(path) => Configuration::from_file(path.as_path())?,
-        None => Configuration::new(options, Some(package_path.clone())),
+        None => Configuration::new(options, Some(package_path.to_owned())),
     };
 
     trace!("Mutator configuration: {mutator_configuration:?}");

--- a/third_party/move/tools/move-mutator/src/operators/ifelse.rs
+++ b/third_party/move/tools/move-mutator/src/operators/ifelse.rs
@@ -141,7 +141,7 @@ mod tests {
         let exp = crate_exp(loc);
         let operator = IfElse::new(exp);
         let source = "if (a) { }";
-        let expected = vec!["if (true) { }", "if (false) { }"];
+        let expected = vec!["if (true) { }", "if (false) { }", "if (!(a)) { }"];
         let result = operator.apply(source);
         assert_eq!(result.len(), expected.len());
         for (i, r) in result.iter().enumerate() {

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -209,6 +209,12 @@ impl MutationReport {
     pub fn get_module_name(&self) -> &str {
         &self.module_name
     }
+
+    /// Return the diff.
+    #[must_use]
+    pub fn get_diff(&self) -> &str {
+        &self.diff
+    }
 }
 
 #[cfg(test)]

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -8,9 +8,10 @@ extern crate log;
 
 use crate::prover::prove;
 use anyhow::anyhow;
+use move_package::source_package::layout::SourcePackageLayout;
 use move_package::BuildConfig;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// This function runs the specification testing, which is a combination of the
 /// mutator tool and the prover tool
@@ -35,42 +36,40 @@ use std::path::PathBuf;
 pub fn run_spec_test(
     options: &cli::CLIOptions,
     config: &BuildConfig,
-    package_path: &PathBuf,
+    package_path: &Path,
 ) -> anyhow::Result<()> {
     // We need to initialize logger using try_init() as it might be already initialized in some other tool
     // (e.g. spec-test). If we use init() instead, we will get an abort.
     let _ = pretty_env_logger::try_init();
 
-    info!("Running spec test {options:?}",);
+    // Check if package is correctly structured.
+    let package_path = SourcePackageLayout::try_find_root(&package_path.canonicalize()?)?;
 
-    let mut mutator_conf = cli::create_mutator_options(options);
+    info!("Running specification tester with the following options: {options:?} and package path: {package_path:?}");
+
     let prover_conf = cli::generate_prover_options(options)?;
 
     // Setup temporary directory structure.
     let outdir = tempfile::tempdir()?.into_path();
-    let outdir_mutant = outdir.join("mutants");
     let outdir_original = outdir.join("base");
 
-    fs::create_dir_all(&outdir_mutant)?;
     fs::create_dir_all(&outdir_original)?;
 
-    if cli::check_mutator_output_path(&mutator_conf).is_none() {
-        mutator_conf.out_mutant_dir = Some(outdir_mutant.clone());
-    }
-
-    debug!("Running the move mutator tool");
-
-    move_mutator::run_move_mutator(mutator_conf, config, package_path)?;
+    let outdir_mutant = if let Some(mutant_path) = &options.use_generated_mutants {
+        mutant_path.clone()
+    } else {
+        run_mutator(options, config, &package_path, &outdir)?
+    };
 
     let report =
         move_mutator::report::Report::load_from_json_file(&outdir_mutant.join("report.json"))?;
 
     // Proving part.
-    move_mutator::compiler::copy_dir_all(package_path, &outdir_original)?;
+    move_mutator::compiler::copy_dir_all(&package_path, &outdir_original)?;
 
     let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
 
-    let result = prove(config, package_path, &prover_conf, &mut error_writer);
+    let result = prove(config, &package_path, &prover_conf, &mut error_writer);
 
     if let Err(e) = result {
         let msg = format!("Original code verification failed! Prover failed with error: {e}");
@@ -81,18 +80,18 @@ pub fn run_spec_test(
     let mut spec_report = report::Report::new();
 
     for elem in report.get_mutants() {
-        spec_report.increment_mutants_tested(elem.original_file_path(), elem.get_module_name());
-
         let mutant_file = elem.mutant_path();
         // Strip prefix to get the path relative to the package directory (or take that path if it's already relative).
         let original_file = elem
             .original_file_path()
-            .strip_prefix(package_path)
+            .strip_prefix(&package_path)
             .unwrap_or(elem.original_file_path());
         let outdir_prove = outdir.join("prove");
 
+        spec_report.increment_mutants_tested(original_file, elem.get_module_name());
+
         let _ = fs::remove_dir_all(&outdir_prove);
-        move_mutator::compiler::copy_dir_all(package_path, &outdir_prove)?;
+        move_mutator::compiler::copy_dir_all(&package_path, &outdir_prove)?;
 
         trace!(
             "Copying mutant file {:?} to the package directory {:?}",
@@ -110,9 +109,14 @@ pub fn run_spec_test(
 
         if let Err(e) = result {
             trace!("Mutant killed! Prover failed with error: {e}");
-            spec_report.increment_mutants_killed(elem.original_file_path(), elem.get_module_name());
+            spec_report.increment_mutants_killed(original_file, elem.get_module_name());
         } else {
             trace!("Mutant hasn't been killed!");
+            spec_report.add_mutants_alive_diff(
+                original_file,
+                elem.get_module_name(),
+                elem.get_diff(),
+            );
         }
     }
 
@@ -125,4 +129,27 @@ pub fn run_spec_test(
     spec_report.print_table();
 
     Ok(())
+}
+
+/// This function runs the Move Mutator tool.
+fn run_mutator(
+    options: &cli::CLIOptions,
+    config: &BuildConfig,
+    package_path: &Path,
+    outdir: &Path,
+) -> anyhow::Result<PathBuf> {
+    debug!("Running the move mutator tool");
+    let mut mutator_conf = cli::create_mutator_options(options);
+
+    let outdir_mutant = if let Some(path) = cli::check_mutator_output_path(&mutator_conf) {
+        path
+    } else {
+        mutator_conf.out_mutant_dir = Some(outdir.join("mutants"));
+        mutator_conf.out_mutant_dir.clone().unwrap()
+    };
+
+    fs::create_dir_all(&outdir_mutant)?;
+    move_mutator::run_move_mutator(mutator_conf, config, package_path)?;
+
+    Ok(outdir_mutant)
 }

--- a/third_party/move/tools/move-spec-test/src/report.rs
+++ b/third_party/move/tools/move-spec-test/src/report.rs
@@ -73,13 +73,19 @@ impl Report {
 
         for (path, stats) in &self.files {
             for stat in stats {
+                let percentage = if stat.tested == 0 {
+                    0.0
+                } else {
+                    f64::from(stat.killed) / f64::from(stat.tested) * 100.0
+                };
+
                 builder.push_record([
                     format!("{}::{}", path.to_string_lossy(), stat.module.clone()),
                     stat.tested.to_string(),
                     stat.killed.to_string(),
                     format!(
                         "{:.2}%",
-                        (f64::from(stat.killed) / f64::from(stat.tested)) * 100.0
+                        percentage
                     ),
                 ]);
             }


### PR DESCRIPTION
### Description

Minor improvements are added by this PR:
1. additional CLI options and cleaning path usage;
2. export diff from report and change mutator call to take Path instead of PathBuf for Move Mutator;
3. add diffs to the report written to the file for Move Specification Tester;

Code cleaning and removing pedantic clippy warnings from the Move Specification Tester.