### PR TITLE
[move-mutator][move-spec-test] review remarks

### DIFF
--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -17,7 +17,7 @@ different code versions (mutants).
 
 Please refer to the design document for more details: [Move Mutator Design](doc/design.md).
 
-## Example Usage
+## Setup check
 
 Please build the whole repository first. In the `aptos-core` directory, run:
 ```bash
@@ -53,18 +53,19 @@ information as the variable allows. To see all the logs run:
 ```bash
 RUST_LOG=trace ./target/debug/aptos move mutate -m third_party/move/tools/move-mutator/tests/move-assets/simple/sources/Sum.move
 ```
-There is possibility to enable logging only for the specific modules. Please
+There is a possibility of enabling logging only for specific modules. Please
 refer to the [env_logger](https://docs.rs/env_logger/latest/env_logger/) documentation for more details.
 
 There are also good tests in the Move Prover repository that can be used to
-check the tool. To run them, just use:
+check the tool. To run them, run:
 ```
 ./target/release/aptos move mutate -m third_party/move/move-prover/tests/sources/functional/arithm.move
 ./target/release/aptos move mutate -m third_party/move/move-prover/tests/sources/functional/bitwise_operators.move
 ./target/release/aptos move mutate -m third_party/move/move-prover/tests/sources/functional/nonlinear_arithm.move
 ./target/release/aptos move mutate -m third_party/move/move-prover/tests/sources/functional/shift.move
 ```
-and observe `mutants_output` directory.
+and observe `mutants_output` directory after each single command. Please note
+that each call overwrites the previous output.
 
 To generate mutants for all files within a test project (for the whole Move 
 package) run:
@@ -73,7 +74,7 @@ package) run:
 ```
 
 Running the above command will generate mutants for all files within the
-`simple` test project and should generate following output:
+`simple` test project and should generate the following output:
 ```
 $ ./target/release/aptos move mutate --package-dir third_party/move/tools/move-mutator/tests/move-assets/simple/
 {
@@ -111,7 +112,7 @@ directory. They can be used to check the mutator tool as well.
 ## Command-line options
 
 Command line options are slightly different when using the `move-cli` tool and
-when using the `aptos` tool. Running tool using either of them will produce
+when using the `aptos` tool. Running a tool using either of them will produce
 the same results as they finally call the same entry point in the mutator code.
 
 To check possible options run:

--- a/third_party/move/tools/move-mutator/README.md
+++ b/third_party/move/tools/move-mutator/README.md
@@ -57,7 +57,7 @@ There is a possibility of enabling logging only for specific modules. Please
 refer to the [env_logger](https://docs.rs/env_logger/latest/env_logger/) documentation for more details.
 
 There are also good tests in the Move Prover repository that can be used to
-check the tool. To run them, run:
+check the tool. To run them, execute:
 ```
 ./target/release/aptos move mutate -m third_party/move/move-prover/tests/sources/functional/arithm.move
 ./target/release/aptos move mutate -m third_party/move/move-prover/tests/sources/functional/bitwise_operators.move

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -29,7 +29,7 @@ pub struct CLIOptions {
     pub downsample_filter: Option<String>,
     /// Remove averagely given percentage of mutants. See the doc for more details.
     #[clap(long)]
-    pub downsampling_ratio_percentage: Option<u64>,
+    pub downsampling_ratio_percentage: Option<usize>,
     /// Optional configuration file. If provided, it will override the default configuration.
     #[clap(long, short, value_parser)]
     pub configuration_file: Option<PathBuf>,

--- a/third_party/move/tools/move-mutator/src/cli.rs
+++ b/third_party/move/tools/move-mutator/src/cli.rs
@@ -67,7 +67,9 @@ impl FromStr for ModuleFilter {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "all" => Ok(ModuleFilter::All),
-            _ => Ok(ModuleFilter::Selected(vec![s.to_string()])),
+            _ => Ok(ModuleFilter::Selected(
+                s.split(',').map(String::from).collect(),
+            )),
         }
     }
 }

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -44,6 +44,10 @@ use move_symbol_pool::Symbol;
 ///
 /// * If any error occurs during the generation, the string with the cause is returned.
 ///
+/// # Panics
+///
+/// This function panics if the source path contains invalid characters.
+///
 /// # Returns
 ///
 /// * `Result<(FilesSourceText, move_compiler::typing::ast::Program), anyhow::Error>` - tuple of `FilesSourceText` and Program if successful, or an error if any error occurs.
@@ -84,7 +88,7 @@ pub fn generate_ast(
 /// This function prepares the compiler for the given package - it resolves all names and dependencies reading them
 /// from the manifest file present at the package root.
 ///
-/// This function is mostly copy of the code present in the `move_package` crate (build_all).
+/// This function is mostly copy of the code present in the `move_package` crate (`build_all`).
 ///
 /// # Arguments
 ///
@@ -336,7 +340,6 @@ fn rewrite_manifest_for_mutant(root: &Path, tempdir: &Path) -> Result<(), anyhow
     manifest
         .dependencies
         .values()
-        .into_iter()
         .chain(manifest.dev_dependencies.values())
         .for_each(|dep| {
             let dep_canon = dep.local.canonicalize();

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -328,7 +328,7 @@ pub fn verify_mutant(
 /// # Returns
 ///
 /// * `Result<(), anyhow::Error>` - Ok if the rewrite is successful, or an error if any error occurs.
-fn rewrite_manifest_for_mutant(root: &Path, tempdir: &Path) -> Result<(), anyhow::Error> {
+pub fn rewrite_manifest_for_mutant(root: &Path, tempdir: &Path) -> Result<(), anyhow::Error> {
     let mut manifest_string = fs::read_to_string(root.join(SourcePackageLayout::Manifest.path()))?;
     let manifest = manifest_parser::parse_move_manifest_string(manifest_string.clone())?;
     let manifest = manifest_parser::parse_source_manifest(manifest)?;

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -37,6 +37,14 @@ impl Configuration {
 
     /// Recognizes the file type based on the file extension.
     /// Currently supported file types are JSON and TOML.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file type is not supported.
+    ///
+    /// # Returns
+    ///
+    /// * `FileType` - The recognized file type.
     fn get_file_type(file_path: &Path) -> anyhow::Result<FileType> {
         match file_path.extension().and_then(|s| s.to_str()) {
             Some("json") => Ok(FileType::JSON),
@@ -46,6 +54,14 @@ impl Configuration {
     }
 
     /// Reads configuration from the configuration file recognizing its type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file type is not supported. or configuration has invalid format.
+    ///
+    /// # Returns
+    ///
+    /// * `Configuration` - The configuration read from the file.
     pub fn from_file(file_path: &Path) -> anyhow::Result<Configuration> {
         let file_type = Configuration::get_file_type(file_path)?;
         debug!("Reading configuration from file type: {:?}", file_type);
@@ -56,6 +72,14 @@ impl Configuration {
     }
 
     /// Reads configuration from the TOML configuration file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file has invalid format.
+    ///
+    /// # Returns
+    ///
+    /// * `Configuration` - The configuration read from the file.
     pub fn from_toml_file(toml_file: &Path) -> anyhow::Result<Configuration> {
         debug!("Reading configuration from TOML file: {:?}", toml_file);
         let toml_source = std::fs::read_to_string(toml_file)?;
@@ -63,12 +87,21 @@ impl Configuration {
     }
 
     /// Reads configuration from the JSON configuration source.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file has invalid format.
+    ///
+    /// # Returns
+    ///
+    /// * `Configuration` - The configuration read from the file.
     pub fn from_json_file(json_file: &Path) -> anyhow::Result<Configuration> {
         debug!("Reading configuration from JSON file: {:?}", json_file);
         Ok(serde_json::from_str(&std::fs::read_to_string(json_file)?)?)
     }
 
     /// Returns the configuration for the given file path.
+    #[must_use]
     pub fn get_file_configuration(&self, file_path: &Path) -> Option<&FileConfiguration> {
         self.individual
             .iter()
@@ -87,6 +120,7 @@ pub struct MutationConfig {
 
 /// Configuration for the individual file.
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(clippy::module_name_repetitions)]
 pub struct FileConfiguration {
     /// The path to the Move source.
     pub file: PathBuf,

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -57,17 +57,17 @@ impl Configuration {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file type is not supported. or configuration has invalid format.
+    /// Returns an error if the file type is unsupported or the configuration has an invalid format.
     ///
     /// # Returns
     ///
     /// * `Configuration` - The configuration read from the file.
-    pub fn from_file(file_path: &Path) -> anyhow::Result<Configuration> {
-        let file_type = Configuration::get_file_type(file_path)?;
+    pub fn from_file(config_path: &Path) -> anyhow::Result<Configuration> {
+        let file_type = Configuration::get_file_type(config_path)?;
         debug!("Reading configuration from file type: {:?}", file_type);
         match file_type {
-            FileType::JSON => Configuration::from_json_file(file_path),
-            FileType::TOML => Configuration::from_toml_file(file_path),
+            FileType::JSON => Configuration::from_json_file(config_path),
+            FileType::TOML => Configuration::from_toml_file(config_path),
         }
     }
 
@@ -75,7 +75,7 @@ impl Configuration {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file has invalid format.
+    /// Returns an error if the file has an invalid format.
     ///
     /// # Returns
     ///
@@ -90,7 +90,7 @@ impl Configuration {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file has invalid format.
+    /// Returns an error if the file has an invalid format.
     ///
     /// # Returns
     ///

--- a/third_party/move/tools/move-mutator/src/configuration.rs
+++ b/third_party/move/tools/move-mutator/src/configuration.rs
@@ -20,7 +20,7 @@ pub struct Configuration {
     /// Configuration for the mutation operators (project-wide).
     pub mutation: Option<MutationConfig>,
     /// Configuration for the individual files. (optional).
-    pub individual: Option<Vec<FileConfiguration>>,
+    pub individual: Vec<FileConfiguration>,
 }
 
 impl Configuration {
@@ -31,7 +31,7 @@ impl Configuration {
             project,
             project_path,
             mutation: None,
-            individual: None,
+            individual: vec![],
         }
     }
 
@@ -70,11 +70,9 @@ impl Configuration {
 
     /// Returns the configuration for the given file path.
     pub fn get_file_configuration(&self, file_path: &Path) -> Option<&FileConfiguration> {
-        self.individual.as_ref().and_then(|individual| {
-            individual
-                .iter()
-                .find(|file_conf| file_conf.file == file_path)
-        })
+        self.individual
+            .iter()
+            .find(|file_conf| file_conf.file == file_path)
     }
 }
 
@@ -283,7 +281,7 @@ mod tests {
             project: CLIOptions::default(),
             project_path: None,
             mutation: None,
-            individual: Some(vec![file_config]),
+            individual: vec![file_config],
         };
 
         let result = config.get_file_configuration(&PathBuf::from("/unknown/path"));

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -89,7 +89,7 @@ pub fn run_move_mutator(
 
             // If the downsample ratio is set, we need to downsample the mutants.
             if let Some(percentage) = mutator_configuration.project.downsampling_ratio_percentage {
-                let to_remove = (mutated_sources.len() as f64 * percentage as f64 / 100.0) as usize;
+                let to_remove = (mutated_sources.len() * percentage).div_ceil(100);
 
                 // Delete randomly elements from the vector.
                 let mut rng = thread_rng();

--- a/third_party/move/tools/move-mutator/src/mutant.rs
+++ b/third_party/move/tools/move-mutator/src/mutant.rs
@@ -36,7 +36,7 @@ impl Mutant {
 
     /// Returns the module name that this mutant is in.
     pub fn get_module_name(&self) -> Option<ModuleName> {
-        self.module_name.clone()
+        self.module_name
     }
 
     /// Sets the module name that this mutant is in.

--- a/third_party/move/tools/move-mutator/src/operator.rs
+++ b/third_party/move/tools/move-mutator/src/operator.rs
@@ -31,6 +31,7 @@ impl MutantInfo {
 /// Trait for mutation operators.
 /// Mutation operators are used to apply mutations to the source code. To keep adding new mutation operators simple,
 /// we use a trait that all mutation operators implement.
+#[allow(clippy::module_name_repetitions)]
 pub trait MutationOperator {
     /// Applies the mutation operator to the given source code.
     /// Returns differently mutated source code listings in a vector.

--- a/third_party/move/tools/move-mutator/src/operators/ifelse.rs
+++ b/third_party/move/tools/move-mutator/src/operators/ifelse.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 
 pub const OPERATOR_NAME: &str = "if_else_replacement";
 
-/// IfElse mutation operator.
+/// `IfElse` mutation operator.
 /// Replaces expressions under the if/else statements with literals.
 #[derive(Debug, Clone)]
 pub struct IfElse {

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -22,6 +22,9 @@ use std::path::{Path, PathBuf};
 /// This function constructs the following output path for file.move:
 /// "`output_dir/file_index.move`"
 ///
+/// Paths can be absolute or relative - it doesn't matter. The function will handle it by
+/// canonicalizing the path. Returned path is always relative to the package directory root.
+///
 /// # Arguments
 ///
 /// * `output_dir` - The directory where the mutant will be output.

--- a/third_party/move/tools/move-mutator/src/output.rs
+++ b/third_party/move/tools/move-mutator/src/output.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 /// "`output_dir/file_index.move`"
 ///
 /// Paths can be absolute or relative - it doesn't matter. The function will handle it by
-/// canonicalizing the path. Returned path is always relative to the package directory root.
+/// canonicalizing the path. The returned path is always relative to the package directory root.
 ///
 /// # Arguments
 ///

--- a/third_party/move/tools/move-mutator/src/report.rs
+++ b/third_party/move/tools/move-mutator/src/report.rs
@@ -27,6 +27,10 @@ impl Report {
     }
 
     /// Saves the `Report` as a JSON file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be created or written to.
     pub fn save_to_json_file(&self, path: &Path) -> Result<()> {
         let file = std::fs::File::create(path)?;
 
@@ -36,6 +40,10 @@ impl Report {
     }
 
     /// Loads the `Report` from a JSON file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened or read from.
     pub fn load_from_json_file(path: &Path) -> Result<Self> {
         info!("Reading report from {}", path.display());
 
@@ -45,6 +53,10 @@ impl Report {
     }
 
     /// Saves the `Report` as a text file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be created or written to.
     pub fn save_to_text_file(&self, path: &Path) -> Result<()> {
         let mut file = std::fs::File::create(path)?;
 
@@ -149,6 +161,7 @@ impl Mutation {
     }
 
     /// Returns the operator name.
+    #[must_use]
     pub fn get_operator_name(&self) -> &str {
         &self.operator_name
     }
@@ -157,6 +170,7 @@ impl Mutation {
 /// The `MutationReport` struct represents an entry in a report.
 /// It contains information about a mutation that was applied to a file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::module_name_repetitions)]
 pub struct MutationReport {
     /// The path to the mutated file.
     mutant_path: PathBuf,

--- a/third_party/move/tools/move-mutator/tests/basic_tests.rs
+++ b/third_party/move/tools/move-mutator/tests/basic_tests.rs
@@ -1,0 +1,182 @@
+use move_mutator::cli::{CLIOptions, ModuleFilter};
+use move_package::BuildConfig;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
+const PACKAGE_PATHS: &[&str] = &[
+    "tests/move-assets/breakcontinue",
+    "tests/move-assets/poor_spec",
+    "tests/move-assets/basic_coin",
+    "tests/move-assets/relative_dep/p2",
+    "tests/move-assets/same_names",
+    "tests/move-assets/simple",
+];
+
+// Check if the mutator works correctly on the basic packages.
+// It should generate a report with mutants.
+#[test]
+fn check_mutator_works_correctly() {
+    let outdir = tempdir().unwrap().into_path();
+
+    let options = CLIOptions {
+        move_sources: vec![],
+        mutate_modules: ModuleFilter::All,
+        out_mutant_dir: Some(outdir.clone()),
+        verify_mutants: false,
+        no_overwrite: false,
+        downsample_filter: None,
+        downsampling_ratio_percentage: None,
+        configuration_file: None,
+    };
+
+    let config = BuildConfig::default();
+
+    for package_path in PACKAGE_PATHS {
+        let package_path = Path::new(package_path);
+
+        let result = move_mutator::run_move_mutator(options.clone(), &config, package_path);
+        assert!(result.is_ok());
+
+        let report_path = outdir.join("report.json");
+        assert!(report_path.exists());
+
+        let report = move_mutator::report::Report::load_from_json_file(&report_path).unwrap();
+        assert!(!report.get_mutants().is_empty());
+    }
+}
+
+#[test]
+fn check_mutator_verify_mutants_correctly() {
+    let outdir = tempdir().unwrap().into_path();
+
+    let options = CLIOptions {
+        move_sources: vec![],
+        mutate_modules: ModuleFilter::All,
+        out_mutant_dir: Some(outdir.clone()),
+        verify_mutants: true,
+        no_overwrite: false,
+        downsample_filter: None,
+        downsampling_ratio_percentage: None,
+        configuration_file: None,
+    };
+
+    let config = BuildConfig::default();
+
+    let package_path = Path::new(PACKAGE_PATHS[1]);
+
+    let result = move_mutator::run_move_mutator(options.clone(), &config, package_path);
+    assert!(result.is_ok());
+
+    let report_path = outdir.join("report.json");
+    assert!(report_path.exists());
+
+    let report = move_mutator::report::Report::load_from_json_file(&report_path).unwrap();
+    assert!(!report.get_mutants().is_empty());
+}
+
+// Check if the mutator fails on non-existing input path.
+#[test]
+fn check_mutator_fails_on_non_existing_path() {
+    let outdir = tempdir().unwrap().into_path();
+
+    let options = CLIOptions {
+        move_sources: vec![],
+        mutate_modules: ModuleFilter::All,
+        out_mutant_dir: Some(outdir.clone()),
+        verify_mutants: false,
+        no_overwrite: false,
+        downsample_filter: None,
+        downsampling_ratio_percentage: None,
+        configuration_file: None,
+    };
+
+    let config = BuildConfig::default();
+
+    let package_path = PathBuf::from("/very/random/path");
+
+    let result = move_mutator::run_move_mutator(options.clone(), &config, &package_path);
+    assert!(result.is_err());
+}
+
+// Check if the mutator fails on non-existing output path.
+#[test]
+fn check_mutator_fails_on_non_existing_output_path() {
+    let options = CLIOptions {
+        move_sources: vec![],
+        mutate_modules: ModuleFilter::All,
+        out_mutant_dir: Some("/very/bad/path".into()),
+        verify_mutants: false,
+        no_overwrite: false,
+        downsample_filter: None,
+        downsampling_ratio_percentage: None,
+        configuration_file: None,
+    };
+
+    let config = BuildConfig::default();
+
+    let package_path = Path::new(PACKAGE_PATHS[0]);
+
+    let result = move_mutator::run_move_mutator(options.clone(), &config, &package_path);
+    assert!(result.is_err());
+}
+
+// Check if the mutator works with single files.
+#[test]
+fn check_mutator_works_with_single_files() {
+    let outdir = tempdir().unwrap().into_path();
+
+    let options = CLIOptions {
+        move_sources: vec!["tests/move-assets/file_without_package/Sub.move".into()],
+        mutate_modules: ModuleFilter::All,
+        out_mutant_dir: Some(outdir.clone()),
+        verify_mutants: false,
+        no_overwrite: false,
+        downsample_filter: None,
+        downsampling_ratio_percentage: None,
+        configuration_file: None,
+    };
+
+    let config = BuildConfig::default();
+
+    let package_path = Path::new(".");
+
+    let result = move_mutator::run_move_mutator(options.clone(), &config, &package_path);
+    assert!(result.is_ok());
+
+    let report_path = outdir.join("report.json");
+    assert!(report_path.exists());
+
+    let report = move_mutator::report::Report::load_from_json_file(&report_path).unwrap();
+    assert!(!report.get_mutants().is_empty());
+}
+
+// Check if the mutator produce zero mutants if verification is enabled for
+// files without any package (we're unable to verify such files successfully).
+#[test]
+fn check_mutator_fails_verify_file_without_package() {
+    let outdir = tempdir().unwrap().into_path();
+
+    let options = CLIOptions {
+        move_sources: vec!["tests/move-assets/file_without_package/Sub.move".into()],
+        mutate_modules: ModuleFilter::All,
+        out_mutant_dir: Some(outdir.clone()),
+        verify_mutants: true,
+        no_overwrite: false,
+        downsample_filter: None,
+        downsampling_ratio_percentage: None,
+        configuration_file: None,
+    };
+
+    let config = BuildConfig::default();
+
+    let package_path = Path::new(".");
+
+    let result = move_mutator::run_move_mutator(options.clone(), &config, &package_path);
+    assert!(result.is_ok());
+
+    let report_path = outdir.join("report.json");
+    assert!(report_path.exists());
+
+    let report = move_mutator::report::Report::load_from_json_file(&report_path).unwrap();
+    assert!(report.get_mutants().is_empty());
+}

--- a/third_party/move/tools/move-spec-test/README.md
+++ b/third_party/move/tools/move-spec-test/README.md
@@ -126,27 +126,29 @@ tests like:
 ```
 
 You should see different results for different modules as it depends on the
-quality of the specifications. Some modules like `Sum` has good specifications
-and all mutants are killed, while others like `Operators` may lack some tests.
+quality of the specifications. Some modules, like `Sum`, have good 
+specifications and all mutants are killed, while some others, like `Operators`
+may not and some mutants are still alive.
 
 You can also try the Move Prover testsuite available in the
 `third_party/move/move-prover/tests/sources/` directory.
 
-To check some real-world examples, you can use the following places:
+To check some real-world examples, apply the `spec-test` tool to these packages:
 - `aptos-move/framework/move-stdlib`
 - `aptos-move/framework/aptos-stdlib`
 
-You should see the results of the tests for the whole stdlib packages. There
-can be some modules which have better specifications quality (more mutants
-killed) and some which have worse quality (fewer mutants killed). It is also
-possible that some modules have no mutants killed at all which can be a sign
-that there are no specifications at all, or they are not tight enough.
+You should see the results of the tests for both stdlib packages. There
+can be some modules with better specification quality (more mutants
+killed) and some with worse quality (fewer mutants killed). Modules
+can have no mutants killed at all, which then can indicate:
+- the module has no specifications at all,
+- the module has poor specifications, which are not tight enough.
 
 It's recommended to generate a report in a JSON format and analyze it to see
-which mutants are not killed and what are the differences between the original
-and modified code. This can help to improve the specifications and make them
-more tight and correct or it may indicate that some specifications some
-mutation operators are not applicable well to that kind of code.
+which mutants are not killed and what the differences are between the original
+and modified code. This can help improve the specifications to make them
+more tight and correct, or it may indicate that some specifications of
+mutation operators do not apply well to that kind of code.
 
 ## Command-line options
 

--- a/third_party/move/tools/move-spec-test/README.md
+++ b/third_party/move/tools/move-spec-test/README.md
@@ -123,11 +123,30 @@ You can try to run the tool using other examples from the `move-mutator`
 tests like:
 ```bash
 ./target/release/move spec-test -p third_party/move/tools/move-mutator/tests/move-assets/simple
-./target/release/move spec-test -p third_party/move/tools/move-mutator/tests/move-assets/breakcontinue -i "Break"
 ```
+
+You should see different results for different modules as it depends on the
+quality of the specifications. Some modules like `Sum` has good specifications
+and all mutants are killed, while others like `Operators` may lack some tests.
 
 You can also try the Move Prover testsuite available in the
 `third_party/move/move-prover/tests/sources/` directory.
+
+To check some real-world examples, you can use the following places:
+- `aptos-move/framework/move-stdlib`
+- `aptos-move/framework/aptos-stdlib`
+
+You should see the results of the tests for the whole stdlib packages. There
+can be some modules which have better specifications quality (more mutants
+killed) and some which have worse quality (fewer mutants killed). It is also
+possible that some modules have no mutants killed at all which can be a sign
+that there are no specifications at all, or they are not tight enough.
+
+It's recommended to generate a report in a JSON format and analyze it to see
+which mutants are not killed and what are the differences between the original
+and modified code. This can help to improve the specifications and make them
+more tight and correct or it may indicate that some specifications some
+mutation operators are not applicable well to that kind of code.
 
 ## Command-line options
 

--- a/third_party/move/tools/move-spec-test/src/cli.rs
+++ b/third_party/move/tools/move-spec-test/src/cli.rs
@@ -122,7 +122,8 @@ mod tests {
                     "move_sources": ["/path/to/move/source"],
                     "out_mutant_dir": "path/to/out_mutant_dir"
                 },
-                "project_path": "/path/to/project"
+                "project_path": "/path/to/project",
+                "individual": []
             }
         "#;
 

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -57,6 +57,16 @@ pub fn run_spec_test(
 
     let prover_conf = cli::generate_prover_options(options)?;
 
+    let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
+
+    let result = prove(config, &package_path, &prover_conf, &mut error_writer);
+
+    if let Err(e) = result {
+        let msg = format!("Original code verification failed! Prover failed with error: {e}");
+        error!("{msg}");
+        return Err(anyhow!(msg));
+    }
+
     // Setup temporary directory structure.
     let outdir = tempfile::tempdir()?.into_path();
     let outdir_original = outdir.join("base");
@@ -77,16 +87,6 @@ pub fn run_spec_test(
 
     // Proving part.
     move_mutator::compiler::copy_dir_all(&package_path, &outdir_original)?;
-
-    let mut error_writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Auto);
-
-    let result = prove(config, &package_path, &prover_conf, &mut error_writer);
-
-    if let Err(e) = result {
-        let msg = format!("Original code verification failed! Prover failed with error: {e}");
-        error!("{msg}");
-        return Err(anyhow!(msg));
-    }
 
     let mut spec_report = report::Report::new();
 

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -129,6 +129,8 @@ pub fn run_spec_test(
             ));
         }
 
+        move_mutator::compiler::rewrite_manifest_for_mutant(&package_path, &outdir_prove)?;
+
         benchmark.start();
         let result = prove(config, &outdir_prove, &prover_conf, &mut error_writer);
         benchmark.stop();

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -92,11 +92,18 @@ pub fn run_spec_test(
 
     let mut proving_benchmarks = vec![Benchmark::new(); report.get_mutants().len()];
     benchmarks.prover.start();
-    for (elem, benchmark) in report
+    for (index, (elem, benchmark)) in report
         .get_mutants()
         .iter()
         .zip(proving_benchmarks.iter_mut())
+        .enumerate()
     {
+        info!(
+            "Proving mutant {} out of {}",
+            index,
+            report.get_mutants().len()
+        );
+
         let mutant_file = elem.mutant_path();
         // Strip prefix to get the path relative to the package directory (or take that path if it's already relative).
         let original_file = elem

--- a/third_party/move/tools/move-spec-test/src/lib.rs
+++ b/third_party/move/tools/move-spec-test/src/lib.rs
@@ -99,8 +99,7 @@ pub fn run_spec_test(
         .enumerate()
     {
         info!(
-            "Proving mutant {} out of {}",
-            index,
+            "Proving mutant {index} out of {}",
             report.get_mutants().len()
         );
 

--- a/third_party/move/tools/move-spec-test/src/report.rs
+++ b/third_party/move/tools/move-spec-test/src/report.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use tabled::{builder::Builder, settings::Style};
 
@@ -9,14 +9,14 @@ use tabled::{builder::Builder, settings::Style};
 #[derive(Debug, Serialize)]
 pub struct Report {
     /// The list of entries in the report.
-    files: HashMap<PathBuf, Vec<MutantStats>>,
+    files: BTreeMap<PathBuf, Vec<MutantStats>>,
 }
 
 impl Report {
     /// Creates a new report.
     pub fn new() -> Self {
         Self {
-            files: HashMap::new(),
+            files: BTreeMap::new(),
         }
     }
 
@@ -27,8 +27,8 @@ impl Report {
     }
 
     /// Increments the number of mutants killed for the given path.
-    /// If the path is not in the report, it adds it with the number of mutants tested and killed
-    /// set to the default (0) and then increases only killed count!
+    /// If the path is not in the report, it adds it with the number of mutants tested set to 0 and killed
+    /// count set to 1.
     pub fn increment_mutants_killed(&mut self, path: &Path, module_name: &str) {
         self.increment_stat(path, module_name, |stat| stat.killed += 1);
     }

--- a/third_party/move/tools/move-spec-test/src/report.rs
+++ b/third_party/move/tools/move-spec-test/src/report.rs
@@ -124,7 +124,7 @@ impl Report {
 
     /// Returns the list of entries in the report.
     #[cfg(test)]
-    pub fn entries(&self) -> &HashMap<PathBuf, Vec<MutantStats>> {
+    pub fn entries(&self) -> &BTreeMap<PathBuf, Vec<MutantStats>> {
         &self.files
     }
 }


### PR DESCRIPTION
### Description
Changes covered in this PR:
- made configuration for individual files to be non-option but plain vector;
- proving original source before mutating;
- rewriting manifest in temporary directory before proving to include all deps;
- fix to accept multiple modules in the modules filter;
- documentation updates;
- simplified usage of individual files configuration.
