### PR TITLE
[move-mutator] use `move-model` AST and compiler v2 backend

### DIFF
--- a/third_party/move/tools/move-mutator/Cargo.toml
+++ b/third_party/move/tools/move-mutator/Cargo.toml
@@ -15,19 +15,23 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.3", features = ["derive"] }
+codespan = "0.11"
 diffy = "0.3"
 either = "1.9"
 itertools = "0.12"
 log = "0.4"
+num-traits = "0.2"
 pretty_env_logger = "0.5"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-tempfile = "3.9"
+tempfile = "3.10"
 toml = "0.5"
 
 move-command-line-common = { path = "../../move-command-line-common" }
 move-compiler = { path = "../../move-compiler" }
+move-compiler-v2 = { path = "../../move-compiler-v2" }
 move-ir-types = { path = "../../move-ir/types" }
+move-model = { path = "../../move-model" }
 move-package = { path = "../move-package" }
 move-symbol-pool = { path = "../../move-symbol-pool" }

--- a/third_party/move/tools/move-mutator/doc/design.md
+++ b/third_party/move/tools/move-mutator/doc/design.md
@@ -113,29 +113,25 @@ application layer with crucial components used to generate mutants:
 
 The functions in the `mutate.rs` are responsible for traversing the Abstract
 Syntax Tree (AST) of the Move source code and searching for places where
-potential mutation operators can be applied. It has been AST from the `typing`
-Move compiler module used, but it may not be a big change to traverse other
-trees (unless the locations pointed by the appropriate structs will match the
-source code). The `typing` tree has been used because it's close enough to
-the original source file, but it offers more information about expression 
-types, which may be needed by some mutation operators.
+potential mutation operators can be applied. It has been AST from the 
+`move-model` package (compiler v2 used).
 
 The idea behind that search is as follows: there is a `mutate` function, which
 is the entry point. It takes the AST of a Move program as input and returns
 a list of mutants (not yet generated). It does this by iterating over the
 source definitions in the AST and calling the appropriate function to traverse
-each definition based on its type (Address, Module, or Script). There are
-several functions to go through different types of AST nodes. 
+each definition based on its type (Address, Module, or Script). The traversal
+is done in the pre-order manner.
 
-The main parsing function is the `parse_expression`. It checks the type of the
-expression and marks that place as the appropriate for the mutation operator to
-be applied (e.g., binary or unary expressions). Sub-expressions are parsed
-recursively.
+The main parsing function is the `parse_expression_and_find_mutants`. It checks
+the type of the expression and marks that place as the appropriate for the 
+mutation operator to be applied (e.g., binary or unary expressions). 
+Sub-expressions are parsed recursively.
 
 When a new place for mutation is found, a new mutant is created. The mutation
 operator is passed as an argument containing the appropriate AST node. As each
-node has its own location (`Spanned` structure with `Loc`) it's possible to
-pass the node without any additional overhead.
+node has its own location it's possible to pass the node without any additional
+overhead.
 
 This process continues recursively until all nodes in the AST have been visited
 and all possible mutants have been generated. The mutate function then returns

--- a/third_party/move/tools/move-mutator/src/compiler.rs
+++ b/third_party/move/tools/move-mutator/src/compiler.rs
@@ -184,11 +184,10 @@ fn prepare_compiler_for_package(
     let mut global_address_map = BTreeMap::new();
     for pack in paths.iter().chain(bytecode_deps.iter()) {
         for (name, val) in &pack.named_address_map {
-            let old = if let Some(old) = global_address_map.insert(name.as_str().to_owned(), *val) {
-                old
-            } else {
+            let Some(old) = global_address_map.insert(name.as_str().to_owned(), *val) else {
                 continue;
             };
+
             if old != *val {
                 let pack_name = pack
                     .name

--- a/third_party/move/tools/move-mutator/src/lib.rs
+++ b/third_party/move/tools/move-mutator/src/lib.rs
@@ -80,7 +80,6 @@ pub fn run_move_mutator(
     let output_dir = output::setup_output_dir(&mutator_configuration)?;
     let mut report: Report = Report::new();
 
-    //for (hash, (filename, source)) in files {
     for fileid in &env.get_source_file_ids() {
         let source = env.get_file_source(*fileid);
         let filename = env.get_file(*fileid);

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -1,13 +1,7 @@
 use crate::cli;
 use crate::configuration::{Configuration, IncludeFunctions};
-use move_compiler::diagnostics::FilesSourceText;
-use move_compiler::parser::ast::{ConstantName, FunctionName, ModuleName};
-use move_compiler::shared::unique_map::UniqueMap;
-use move_compiler::typing::ast;
-use move_compiler::typing::ast::{
-    Constant, Exp, ExpListItem, Function, FunctionBody_, ModuleDefinition, SequenceItem_,
-};
-use move_compiler::{expansion, parser};
+use move_model::ast::{Exp, ExpData, Operation};
+use move_model::model::{FunctionEnv, GlobalEnv, Loc, ModuleEnv};
 use move_package::source_package::layout::SourcePackageLayout;
 use std::path::Path;
 
@@ -20,29 +14,25 @@ use crate::operators::delete_stmt::DeleteStmt;
 use crate::operators::ifelse::IfElse;
 use crate::operators::literal::Literal;
 use crate::operators::unary::Unary;
+use crate::operators::ExpLoc;
 
 /// Traverses the AST, identifies places where mutation operators can be applied
 /// and returns a list of mutants.
-pub fn mutate(
-    ast: ast::Program,
-    conf: &Configuration,
-    files: &FilesSourceText,
-) -> anyhow::Result<Vec<Mutant>> {
+pub fn mutate(env: &GlobalEnv, conf: &Configuration) -> anyhow::Result<Vec<Mutant>> {
     trace!("Starting mutation process");
-    let mut mutants = ast
-        .modules
-        .into_iter()
-        .map(|module| traverse_module_with_check(&module, conf, files))
+    let mutants = env
+        .get_modules()
+        .map(|module| traverse_module_with_check(&module, conf))
         .collect::<Result<Vec<_>, _>>()?
         .concat();
 
-    mutants.extend(
-        ast.scripts
+    /*mutants.extend(
+        env.scripts
             .into_values()
             .map(|script| traverse_function((script.function_name, script.function), conf, files))
             .collect::<Result<Vec<_>, _>>()?
             .concat(),
-    );
+    );*/
 
     trace!("Found {} possible mutations", mutants.len());
 
@@ -53,16 +43,15 @@ pub fn mutate(
 /// that are not included in the configuration.
 #[inline]
 fn traverse_module_with_check(
-    module: &(expansion::ast::ModuleIdent, ast::ModuleDefinition),
+    module: &ModuleEnv<'_>,
     conf: &Configuration,
-    files: &FilesSourceText,
 ) -> anyhow::Result<Vec<Mutant>> {
+    let module_name = module.env.symbol_pool().string(module.get_name().name());
+
     // We need to check if module comes from our source tree or from the deps, as we don't want to traverse
     // all the dependencies. That's a bit tricky as global deps are easy to identify but local deps can be
     // anywhere near the project tree.
-    let (ident, _) = &module;
-    let (filename, _) = files.get(&ident.loc.file_hash()).unwrap(); // File must exist inside the hashmap so it's safe to unwrap.
-    let filename_path = Path::new(filename.as_str());
+    let filename_path = Path::new(module.get_source_path());
 
     if !conf.project.move_sources.is_empty()
         && !conf
@@ -72,7 +61,7 @@ fn traverse_module_with_check(
     {
         trace!(
             "Skipping module {} as it does not come from source project",
-            filename
+            module_name
         );
         return Ok(vec![]);
     }
@@ -84,7 +73,7 @@ fn traverse_module_with_check(
             if test_root != project_path {
                 trace!(
                     "Skipping module: \n {} \n root: {} \n as it does not come from source project {}",
-                    filename_path.to_string_lossy(), test_root.to_string_lossy(),
+                    module_name, test_root.to_string_lossy(),
                     project_path.to_string_lossy()
                 );
                 return Ok(vec![]);
@@ -93,73 +82,33 @@ fn traverse_module_with_check(
     }
 
     // Now we need to check if the module is included in the configuration.
-    let module_name = extract_module_name(module);
     if let cli::ModuleFilter::Selected(mods) = &conf.project.mutate_modules {
-        if !mods.contains(&module_name.to_string()) {
-            trace!("Skipping module {}", module_name.to_string());
+        if !mods.contains(&module_name) {
+            trace!("Skipping module {}", module_name);
             return Ok(vec![]);
         }
     }
 
-    traverse_module(module, conf, files)
-}
-
-/// Internal helper function that returns a reference to the functions defined in the module.
-fn functions_of(
-    module: &(expansion::ast::ModuleIdent, ast::ModuleDefinition),
-) -> &UniqueMap<FunctionName, Function> {
-    let (_, module) = module;
-    let ModuleDefinition { functions, .. } = module;
-    functions
-}
-
-/// Internal helper function that returns a reference to the constants defined in the module.
-fn constants_of(
-    module: &(expansion::ast::ModuleIdent, ast::ModuleDefinition),
-) -> &UniqueMap<ConstantName, Constant> {
-    let (_, module) = module;
-    let ModuleDefinition { constants, .. } = module;
-    constants
-}
-
-/// Extracts the module name from the module declaration.
-fn extract_module_name(
-    module: &(expansion::ast::ModuleIdent, ast::ModuleDefinition),
-) -> ModuleName {
-    let (module_ident, _) = module;
-    module_ident.value.module
+    traverse_module(module, conf)
 }
 
 /// Traverses a single module and returns a list of mutants.
 /// Checks all the functions and constants defined in the module.
 #[allow(clippy::unnecessary_to_owned)]
-fn traverse_module(
-    module: &(expansion::ast::ModuleIdent, ast::ModuleDefinition),
-    conf: &Configuration,
-    files: &FilesSourceText,
-) -> anyhow::Result<Vec<Mutant>> {
-    let module_name = extract_module_name(module);
-    trace!("Traversing module {}", &module_name.to_string());
-    let mut mutants = functions_of(module)
-        .to_owned()
-        .into_iter()
-        .map(|func| traverse_function(func, conf, files))
+fn traverse_module(module: &ModuleEnv<'_>, conf: &Configuration) -> anyhow::Result<Vec<Mutant>> {
+    let module_name = module.env.symbol_pool().string(module.get_name().name());
+
+    trace!("Traversing module {}", &module_name);
+    let mut mutants = module
+        .get_functions()
+        .map(|func| traverse_function(&func, conf))
         .collect::<Result<Vec<_>, _>>()?
         .concat();
-
-    mutants.extend(
-        constants_of(module)
-            .to_owned()
-            .into_iter()
-            .map(|(_, constant)| parse_expression_and_find_mutants(constant.value))
-            .collect::<Result<Vec<_>, _>>()?
-            .concat(),
-    );
 
     // Set the module name for all the mutants.
     mutants
         .iter_mut()
-        .for_each(|m| m.set_module_name(module_name));
+        .for_each(|m| m.set_module_name((*module_name).clone()));
 
     trace!(
         "Found {} possible mutations in module {}",
@@ -169,26 +118,25 @@ fn traverse_module(
     Ok(mutants)
 }
 
-/// Extracts the function name from the function declaration.
-fn extract_function_name(function: &(FunctionName, Function)) -> String {
-    let (function_name, _) = function;
-    let FunctionName(name) = function_name;
-    name.to_string()
-}
-
 /// Traverses a single function and returns a list of mutants.
-/// Checks the body of the function by traversing all the sequences.
+/// Checks the body of the function by traversing its definition.
 fn traverse_function(
-    function: (parser::ast::FunctionName, ast::Function),
+    function: &FunctionEnv<'_>,
     conf: &Configuration,
-    files: &FilesSourceText,
 ) -> anyhow::Result<Vec<Mutant>> {
-    let function_name = extract_function_name(&function);
-    let (fname, function) = function;
-    let (filename, _) = files.get(&function.body.loc.file_hash()).unwrap(); // File must exist inside the hashmap so it's safe to unwrap.
+    let mut spec_blocks_loc = Vec::<Loc>::new();
+
+    let function_name = (*function
+        .module_env
+        .env
+        .symbol_pool()
+        .string(function.get_name()))
+    .clone();
+
+    let filename = function.module_env.get_source_path();
 
     // Check if function is included in individual configuration.
-    if let Some(ind) = conf.get_file_configuration(Path::new(filename.as_str())) {
+    if let Some(ind) = conf.get_file_configuration(Path::new(filename)) {
         if let IncludeFunctions::Selected(funcs) = &ind.include_functions {
             if !funcs.contains(&function_name) {
                 trace!("Skipping function {}", &function_name);
@@ -198,159 +146,143 @@ fn traverse_function(
     }
 
     trace!("Traversing function {}", &function_name);
-    let mut result = match function.body.value {
-        FunctionBody_::Defined(elem) => traverse_sequence(elem),
-        FunctionBody_::Native => Ok(vec![]),
+    let mut result = Vec::<Mutant>::new();
+    if let Some(exp) = function.get_def() {
+        exp.visit_pre_order(&mut |exp_data| {
+            // Collect the spec blocks locations.
+            if let ExpData::SpecBlock(_, _) = exp_data {
+                spec_blocks_loc.push(function.module_env.env.get_node_loc(exp_data.node_id()));
+            }
+
+            // Check if we are not inside of any spec block. If so, don't process expression.
+            // We can't simply return false to stop visiting that tree branch as it will stop
+            // visiting the whole tree.
+            // Visiting pre-order ensures us that we can't process any expression below spec block before
+            // we have visited spec block itself.
+            let exp_loc = function.module_env.env.get_node_loc(exp_data.node_id());
+            if !spec_blocks_loc
+                .iter()
+                .any(|loc| !loc.span().disjoint(exp_loc.span()))
+            {
+                result.extend(parse_expression_and_find_mutants(function, exp_data));
+            }
+            true
+        });
     };
 
-    if let Ok(result) = &mut result {
-        // Set the function name for all the mutants.
-        result.iter_mut().for_each(|m| m.set_function_name(fname));
-    }
-
     result
-}
+        .iter_mut()
+        .for_each(|m| m.set_function_name(function_name.clone()));
 
-/// Traverses a sequence and returns a list of mutants.
-/// Checks all the sequence items by calling `traverse_sequence_item` on them. Sequence can also contain
-/// return expression which needs to be also examined if it can be mutated.
-fn traverse_sequence(elem: ast::Sequence) -> anyhow::Result<Vec<Mutant>> {
-    trace!("Traversing sequence {elem:?}");
-
-    let mutants = elem
-        .into_iter()
-        .map(traverse_sequence_item)
-        .collect::<Result<Vec<_>, _>>()?
-        .concat();
-
-    trace!("Found {} possible mutations in sequence", mutants.len());
-    Ok(mutants)
-}
-
-/// Traverses a single sequence item and returns a list of mutants.
-/// Checks if binds or sequence items contain expressions that can be mutated by calling appropriate function on them..
-fn traverse_sequence_item(seq_item: ast::SequenceItem) -> anyhow::Result<Vec<Mutant>> {
-    trace!("Traversing sequence item {:?}", seq_item);
-    match seq_item.value {
-        SequenceItem_::Bind(_, _, exp) | SequenceItem_::Seq(exp) => {
-            parse_expression_and_find_mutants(*exp)
-        },
-        SequenceItem_::Declare(_bl) => Ok(vec![]),
-    }
-}
-
-/// Helper function that parses a list of expressions and returns a list of mutants.
-fn parse_expressions(exp: Vec<Exp>) -> anyhow::Result<Vec<Mutant>> {
-    trace!("Parsing expressions {exp:?}");
-    Ok(exp
-        .into_iter()
-        .map(parse_expression_and_find_mutants)
-        .collect::<Result<Vec<_>, _>>()?
-        .concat())
+    Ok(result)
 }
 
 /// This function does the actual parsing of the expression and checks if any of the mutation operators
 /// can be applied to it.
-/// In case if the expression contains another expressions, it calls itself recursively.
 /// When Move language is extended with new expressions, this function needs to be updated to support them.
-fn parse_expression_and_find_mutants(exp: Exp) -> anyhow::Result<Vec<Mutant>> {
+fn parse_expression_and_find_mutants(function: &FunctionEnv<'_>, exp: &ExpData) -> Vec<Mutant> {
+    let convert_exps_to_explocs = |exps: &[Exp]| -> Vec<ExpLoc> {
+        exps.iter()
+            .map(|e| ExpLoc {
+                exp: e.clone(),
+                loc: function.module_env.env.get_node_loc(e.node_id()),
+            })
+            .collect::<Vec<ExpLoc>>()
+    };
+
     trace!("Parsing expression {exp:?}");
-    match exp.clone().exp.value {
-        ast::UnannotatedExp_::BinopExp(left, binop, _type, right) => {
-            // Parse left and right side of the operator as they are expressions and may contain
-            // another things to mutate.
-            let mut mutants = parse_expression_and_find_mutants(*left.clone())?;
-            mutants.extend(parse_expression_and_find_mutants(*right.clone())?);
+    match exp {
+        ExpData::Call(node_id, op, exps) => match op {
+            Operation::MoveTo => vec![Mutant::new(MutationOp::DeleteStmt(DeleteStmt::new(
+                exp.clone().into_exp(),
+                function.module_env.env.get_node_loc(*node_id),
+            )))],
+            Operation::Add
+            | Operation::Sub
+            | Operation::Mul
+            | Operation::Div
+            | Operation::Mod
+            | Operation::And
+            | Operation::Or
+            | Operation::Eq
+            | Operation::Neq
+            | Operation::Ge
+            | Operation::Gt
+            | Operation::Le
+            | Operation::Lt
+            | Operation::BitAnd
+            | Operation::BitOr
+            | Operation::Shl
+            | Operation::Shr
+            | Operation::Xor => {
+                let exps_loc = convert_exps_to_explocs(exps);
+                let mut result = vec![Mutant::new(MutationOp::BinaryOp(Binary::new(
+                    op.clone(),
+                    function.module_env.env.get_node_loc(*node_id),
+                    exps_loc.clone(),
+                )))];
 
-            // Add the mutation operator to the list of mutants.
-            mutants.push(Mutant::new(MutationOp::BinaryOp(Binary::new(binop))));
-            mutants.push(Mutant::new(MutationOp::BinarySwap(BinarySwap::new(
-                binop, *left, *right,
-            ))));
+                result.push(Mutant::new(MutationOp::BinarySwap(BinarySwap::new(
+                    op.clone(),
+                    function.module_env.env.get_node_loc(*node_id),
+                    exps_loc,
+                ))));
 
-            trace!("Found possible mutation in BinaryExp {binop:?}");
+                result
+            },
+            Operation::Not => {
+                let exps_loc = convert_exps_to_explocs(exps);
+                vec![Mutant::new(MutationOp::UnaryOp(Unary::new(
+                    op.clone(),
+                    function.module_env.env.get_node_loc(*node_id),
+                    exps_loc,
+                )))]
+            },
+            _ => vec![],
+        },
+        ExpData::IfElse(_, cond, if_exp, else_exp) => {
+            let cond_loc = ExpLoc {
+                exp: cond.clone(),
+                loc: function.module_env.env.get_node_loc(cond.node_id()),
+            };
+            let if_exp_loc = ExpLoc {
+                exp: if_exp.clone(),
+                loc: function.module_env.env.get_node_loc(if_exp.node_id()),
+            };
+            let else_exp_loc = ExpLoc {
+                exp: else_exp.clone(),
+                loc: function.module_env.env.get_node_loc(else_exp.node_id()),
+            };
+            vec![Mutant::new(MutationOp::IfElse(IfElse::new(
+                cond_loc,
+                if_exp_loc,
+                else_exp_loc,
+            )))]
+        },
+        ExpData::Value(node_id, value) => {
+            let mutants = vec![Mutant::new(MutationOp::Literal(Literal::new(
+                value.clone(),
+                function.module_env.env.get_node_type(*node_id),
+                function.module_env.env.get_node_loc(*node_id),
+            )))];
+            mutants
+        },
+        ExpData::LoopCont(node_id, _) => vec![Mutant::new(MutationOp::BreakContinue(
+            BreakContinue::new(function.module_env.env.get_node_loc(*node_id)),
+        ))],
 
-            Ok(mutants)
-        },
-        ast::UnannotatedExp_::UnaryExp(unop, exp) => {
-            // Parse the expression as it may contain another things to mutate.
-            let mut mutants = parse_expression_and_find_mutants(*exp)?;
-
-            // Add the mutation operator to the list of mutants.
-            mutants.push(Mutant::new(MutationOp::UnaryOp(Unary::new(unop))));
-
-            trace!("Found possible mutation in UnaryExp {unop:?}");
-
-            Ok(mutants)
-        },
-        ast::UnannotatedExp_::Assign(_, _, exp) => {
-            let mutants = parse_expression_and_find_mutants(*exp)?;
-            Ok(mutants)
-        },
-        ast::UnannotatedExp_::While(exp1, exp2) | ast::UnannotatedExp_::Mutate(exp1, exp2) => {
-            let mut mutants = parse_expression_and_find_mutants(*exp1)?;
-            mutants.extend(parse_expression_and_find_mutants(*exp2)?);
-            Ok(mutants)
-        },
-        ast::UnannotatedExp_::Block(seq) => traverse_sequence(seq),
-        ast::UnannotatedExp_::Pack(_, _, _, exps) => {
-            let exps = exps
-                .into_iter()
-                .map(|(_, exp)| exp.1 .1)
-                .collect::<Vec<Exp>>();
-            parse_expressions(exps)
-        },
-        ast::UnannotatedExp_::ExpList(exps) => {
-            let exps = exps
-                .into_iter()
-                .map(|exp| match exp {
-                    ExpListItem::Single(exp, _) | ExpListItem::Splat(_, exp, _) => exp,
-                })
-                .collect::<Vec<Exp>>();
-            parse_expressions(exps)
-        },
-        ast::UnannotatedExp_::IfElse(exp1, exp2, exp3) => {
-            let mut mutants = parse_expression_and_find_mutants(*exp1)?;
-            mutants.extend(parse_expression_and_find_mutants(*exp2)?);
-            mutants.extend(parse_expression_and_find_mutants(*exp3)?);
-            mutants.push(Mutant::new(MutationOp::IfElse(IfElse::new(exp))));
-            Ok(mutants)
-        },
-        ast::UnannotatedExp_::Break | ast::UnannotatedExp_::Continue => Ok(vec![Mutant::new(
-            MutationOp::BreakContinue(BreakContinue::new(exp)),
-        )]),
-        ast::UnannotatedExp_::Value(val) => {
-            let mutants = vec![Mutant::new(MutationOp::Literal(Literal::new(val)))];
-            Ok(mutants)
-        },
-        ast::UnannotatedExp_::Builtin(_, expr) => {
-            let mut mutants = parse_expression_and_find_mutants(*expr)?;
-            mutants.push(Mutant::new(MutationOp::DeleteStmt(DeleteStmt::new(
-                exp.clone(),
-            ))));
-            Ok(mutants)
-        },
-        ast::UnannotatedExp_::Abort(exp)
-        | ast::UnannotatedExp_::Annotate(exp, _)
-        | ast::UnannotatedExp_::Borrow(_, exp, _)
-        | ast::UnannotatedExp_::Cast(exp, _)
-        | ast::UnannotatedExp_::Dereference(exp)
-        | ast::UnannotatedExp_::Lambda(_, exp)
-        | ast::UnannotatedExp_::Return(exp)
-        | ast::UnannotatedExp_::VarCall(_, exp)
-        | ast::UnannotatedExp_::Vector(_, _, _, exp)
-        | ast::UnannotatedExp_::TempBorrow(_, exp) => parse_expression_and_find_mutants(*exp),
-        ast::UnannotatedExp_::Loop { has_break: _, body } => {
-            parse_expression_and_find_mutants(*body)
-        },
-        ast::UnannotatedExp_::Unit { .. }
-        | ast::UnannotatedExp_::Copy { .. }
-        | ast::UnannotatedExp_::Move { .. }
-        | ast::UnannotatedExp_::Use(_)
-        | ast::UnannotatedExp_::Constant(_, _)
-        | ast::UnannotatedExp_::ModuleCall(_)
-        | ast::UnannotatedExp_::BorrowLocal(_, _)
-        | ast::UnannotatedExp_::Spec(_)
-        | ast::UnannotatedExp_::UnresolvedError => Ok(vec![]),
+        ExpData::Return(_, _)
+        | ExpData::Mutate(_, _, _)
+        | ExpData::Assign(_, _, _)
+        | ExpData::Block(_, _, _, _)
+        | ExpData::Invoke(_, _, _)
+        | ExpData::Lambda(_, _, _)
+        | ExpData::LocalVar(_, _)
+        | ExpData::Loop(_, _)
+        | ExpData::Temporary(_, _)
+        | ExpData::SpecBlock(_, _)
+        | ExpData::Sequence(_, _)
+        | ExpData::Quant(_, _, _, _, _, _)
+        | ExpData::Invalid(_) => vec![],
     }
 }

--- a/third_party/move/tools/move-mutator/src/mutate.rs
+++ b/third_party/move/tools/move-mutator/src/mutate.rs
@@ -26,14 +26,6 @@ pub fn mutate(env: &GlobalEnv, conf: &Configuration) -> anyhow::Result<Vec<Mutan
         .collect::<Result<Vec<_>, _>>()?
         .concat();
 
-    /*mutants.extend(
-        env.scripts
-            .into_values()
-            .map(|script| traverse_function((script.function_name, script.function), conf, files))
-            .collect::<Result<Vec<_>, _>>()?
-            .concat(),
-    );*/
-
     trace!("Found {} possible mutations", mutants.len());
 
     Ok(mutants)
@@ -59,10 +51,7 @@ fn traverse_module_with_check(
             .move_sources
             .contains(&filename_path.to_path_buf())
     {
-        trace!(
-            "Skipping module {} as it does not come from source project",
-            module_name
-        );
+        trace!("Skipping module {module_name} as it does not come from source project");
         return Ok(vec![]);
     }
 
@@ -72,8 +61,8 @@ fn traverse_module_with_check(
             let project_path = project_path.canonicalize()?;
             if test_root != project_path {
                 trace!(
-                    "Skipping module: \n {} \n root: {} \n as it does not come from source project {}",
-                    module_name, test_root.to_string_lossy(),
+                    "Skipping module: \n {module_name} \n root: {} \n as it does not come from source project {}",
+                    test_root.to_string_lossy(),
                     project_path.to_string_lossy()
                 );
                 return Ok(vec![]);
@@ -84,7 +73,7 @@ fn traverse_module_with_check(
     // Now we need to check if the module is included in the configuration.
     if let cli::ModuleFilter::Selected(mods) = &conf.project.mutate_modules {
         if !mods.contains(&module_name) {
-            trace!("Skipping module {}", module_name);
+            trace!("Skipping module {module_name}");
             return Ok(vec![]);
         }
     }
@@ -154,7 +143,7 @@ fn traverse_function(
                 spec_blocks_loc.push(function.module_env.env.get_node_loc(exp_data.node_id()));
             }
 
-            // Check if we are not inside of any spec block. If so, don't process expression.
+            // Check if we are not inside of any spec block. If so, don't process the expression.
             // We can't simply return false to stop visiting that tree branch as it will stop
             // visiting the whole tree.
             // Visiting pre-order ensures us that we can't process any expression below spec block before

--- a/third_party/move/tools/move-mutator/src/operators/binary_swap.rs
+++ b/third_party/move/tools/move-mutator/src/operators/binary_swap.rs
@@ -1,8 +1,9 @@
 use crate::operator::{MutantInfo, MutationOperator};
+use crate::operators::ExpLoc;
 use crate::report::{Mutation, Range};
-use move_command_line_common::files::FileHash;
-use move_compiler::parser::ast::{BinOp, BinOp_};
-use move_compiler::typing::ast::Exp;
+use codespan::FileId;
+use move_model::ast::Operation;
+use move_model::model::Loc;
 use std::fmt;
 
 pub const OPERATOR_NAME: &str = "binary_operator_swap";
@@ -10,17 +11,17 @@ pub const OPERATOR_NAME: &str = "binary_operator_swap";
 /// The binary swap mutation operator.
 #[derive(Debug, Clone)]
 pub struct BinarySwap {
-    operator: BinOp,
-    left: Exp,
-    right: Exp,
+    operation: Operation,
+    loc: Loc,
+    exps: Vec<ExpLoc>,
 }
 
 impl BinarySwap {
-    pub fn new(operator: BinOp, left: Exp, right: Exp) -> Self {
+    pub fn new(operation: Operation, loc: Loc, exps: Vec<ExpLoc>) -> Self {
         Self {
-            operator,
-            left,
-            right,
+            operation,
+            loc,
+            exps,
         }
     }
 }
@@ -28,29 +29,50 @@ impl BinarySwap {
 impl MutationOperator for BinarySwap {
     fn apply(&self, source: &str) -> Vec<MutantInfo> {
         // There is no point in swapping the operator for these cases as it would result in the same expression.
-        if self.operator.value == BinOp_::Add
-            || self.operator.value == BinOp_::Mul
-            || self.operator.value == BinOp_::Eq
-            || self.operator.value == BinOp_::Neq
+        if self.operation == Operation::Add
+            || self.operation == Operation::Mul
+            || self.operation == Operation::Eq
+            || self.operation == Operation::Neq
         {
             return vec![];
         }
 
-        let start = self.left.exp.loc.start() as usize;
-        let end = self.right.exp.loc.end() as usize;
+        // Check if we've exactly two expressions.
+        if self.exps.len() != 2 {
+            warn!(
+                "BinarySwapOperator: Expected exactly two expressions, got {}",
+                self.exps.len()
+            );
+            return vec![];
+        }
+
+        // We need to extract operator position, but we must use the positions of expressions to avoid
+        // extracting the operator of a different binary expression.
+        let left = &self.exps[0].loc;
+        let right = &self.exps[1].loc;
+        let start = left.span().end().to_usize();
+        // Adjust start to omit whitespaces before the operator
+        let start = source[start..]
+            .find(|c: char| !c.is_whitespace())
+            .map_or(start, |i| start + i);
+        let end = right.span().start().to_usize();
+        // Adjust end to omit whitespaces after the operator
+        let end = source[..end]
+            .rfind(|c: char| !c.is_whitespace())
+            .map_or(end, |i| i + 1);
+        let binop_str = &source[start..end];
+
+        let start = left.span().start().to_usize();
+        let end = right.span().end().to_usize();
         let cur_op = &source[start..end];
 
-        let left_str =
-            &source[self.left.exp.loc.start() as usize..self.left.exp.loc.end() as usize];
-        let right_str =
-            &source[self.right.exp.loc.start() as usize..self.right.exp.loc.end() as usize];
-        let binop_str =
-            &source[self.operator.loc.start() as usize..self.operator.loc.end() as usize];
+        let left_str = &source[left.span().start().to_usize()..left.span().end().to_usize()];
+        let right_str = &source[right.span().start().to_usize()..right.span().end().to_usize()];
 
         let mut mutated_source = source.to_string();
         let mut op = right_str.to_owned();
-        op.push_str(&binop_str);
-        op.push_str(&left_str);
+        op.push_str(binop_str);
+        op.push_str(left_str);
 
         mutated_source.replace_range(start..end, op.as_str());
 
@@ -66,8 +88,8 @@ impl MutationOperator for BinarySwap {
     }
 
     // We can use either `left` or `right` as they have to be in one file.
-    fn get_file_hash(&self) -> FileHash {
-        self.left.exp.loc.file_hash()
+    fn get_file_id(&self) -> FileId {
+        self.loc.file_id()
     }
 
     fn name(&self) -> String {
@@ -79,10 +101,25 @@ impl fmt::Display for BinarySwap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "BinarySwapOperator(location: file hash: {}, index start: {}, index stop: {})",
-            self.get_file_hash(),
-            self.left.exp.loc.start(),
-            self.right.exp.loc.end()
+            "BinarySwapOperator(location: file id: {:?}, index start: {}, index stop: {})",
+            self.loc.file_id(),
+            self.exps[0].loc.span().start().to_usize(),
+            self.exps[1].loc.span().end().to_usize()
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codespan::Files;
+
+    #[test]
+    fn test_get_file_id() {
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 0));
+        let operator = BinarySwap::new(Operation::Add, loc, vec![]);
+        assert_eq!(operator.get_file_id(), fid);
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/break_continue.rs
+++ b/third_party/move/tools/move-mutator/src/operators/break_continue.rs
@@ -1,9 +1,8 @@
 use crate::operator::{MutantInfo, MutationOperator};
 use crate::operators::{MOVE_BREAK, MOVE_CONTINUE, MOVE_EMPTY_STMT};
 use crate::report::{Mutation, Range};
-use move_command_line_common::files::FileHash;
-use move_compiler::typing::ast;
-use move_compiler::typing::ast::UnannotatedExp_;
+use codespan::FileId;
+use move_model::model::Loc;
 use std::fmt;
 use std::fmt::Debug;
 
@@ -13,29 +12,29 @@ pub const OPERATOR_NAME: &str = "break_continue_replacement";
 /// Replaces break and continue statements with each other or deletes them.
 #[derive(Debug, Clone)]
 pub struct BreakContinue {
-    operation: ast::Exp,
+    loc: Loc,
 }
 
 impl BreakContinue {
     /// Creates a new instance of the break/continue mutation operator.
     #[must_use]
-    pub fn new(operation: ast::Exp) -> Self {
-        Self { operation }
+    pub fn new(loc: Loc) -> Self {
+        Self { loc }
     }
 }
 
 impl MutationOperator for BreakContinue {
     fn apply(&self, source: &str) -> Vec<MutantInfo> {
-        let start = self.operation.exp.loc.start() as usize;
-        let end = self.operation.exp.loc.end() as usize;
+        let start = self.loc.span().start().to_usize();
+        let end = self.loc.span().end().to_usize();
         let cur_op = &source[start..end];
 
         // Group of exchangeable break/continue statements.
-        let ops: Vec<&str> = match self.operation.exp.value {
-            UnannotatedExp_::Break => {
+        let ops: Vec<&str> = match cur_op {
+            "break" => {
                 vec![MOVE_CONTINUE, MOVE_EMPTY_STMT]
             },
-            UnannotatedExp_::Continue => {
+            "continue" => {
                 vec![MOVE_BREAK, MOVE_EMPTY_STMT]
             },
             _ => vec![],
@@ -58,8 +57,8 @@ impl MutationOperator for BreakContinue {
             .collect()
     }
 
-    fn get_file_hash(&self) -> FileHash {
-        self.operation.exp.loc.file_hash()
+    fn get_file_id(&self) -> FileId {
+        self.loc.file_id()
     }
 
     fn name(&self) -> String {
@@ -71,11 +70,10 @@ impl fmt::Display for BreakContinue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "BreakContinueOperator({:?}, location: file hash: {}, index start: {}, index stop: {})",
-            self.operation.exp.value,
-            self.operation.exp.loc.file_hash(),
-            self.operation.exp.loc.start(),
-            self.operation.exp.loc.end()
+            "BreakContinueOperator(location: file id: {:?}, index start: {}, index stop: {})",
+            self.loc.file_id(),
+            self.loc.span().start(),
+            self.loc.span().end()
         )
     }
 }
@@ -83,48 +81,15 @@ impl fmt::Display for BreakContinue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use move_command_line_common::files::FileHash;
-    use move_compiler::naming::ast::{Type, Type_};
-    use move_compiler::typing::ast::{Exp, UnannotatedExp, UnannotatedExp_};
-    use move_ir_types::location::Loc;
-
-    #[test]
-    fn test_apply_break() {
-        let loc = Loc::new(FileHash::new(""), 0, 5);
-        let exp = Exp {
-            exp: UnannotatedExp {
-                value: UnannotatedExp_::Break,
-                loc,
-            },
-            ty: Type {
-                value: Type_::Anything,
-                loc,
-            },
-        };
-        let operator = BreakContinue::new(exp);
-        let source = MOVE_BREAK;
-        let expected = vec![MOVE_CONTINUE, MOVE_EMPTY_STMT];
-        let result = operator.apply(source);
-        assert_eq!(result.len(), expected.len());
-        for (i, r) in result.iter().enumerate() {
-            assert_eq!(r.mutated_source, expected[i]);
-        }
-    }
+    use codespan::Files;
 
     #[test]
     fn test_apply_continue() {
-        let loc = Loc::new(FileHash::new(""), 0, 8);
-        let exp = Exp {
-            exp: UnannotatedExp {
-                value: UnannotatedExp_::Continue,
-                loc,
-            },
-            ty: Type {
-                value: Type_::Anything,
-                loc,
-            },
-        };
-        let operator = BreakContinue::new(exp);
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 8));
+
+        let operator = BreakContinue::new(loc);
         let source = MOVE_CONTINUE;
         let expected = vec![MOVE_BREAK, MOVE_EMPTY_STMT];
         let result = operator.apply(source);
@@ -135,19 +100,11 @@ mod tests {
     }
 
     #[test]
-    fn test_get_file_hash() {
-        let loc = Loc::new(FileHash::new(""), 0, 0);
-        let exp = Exp {
-            exp: UnannotatedExp {
-                value: UnannotatedExp_::Break,
-                loc,
-            },
-            ty: Type {
-                value: Type_::Anything,
-                loc,
-            },
-        };
-        let operator = BreakContinue::new(exp);
-        assert_eq!(operator.get_file_hash(), FileHash::new(""));
+    fn test_get_file_id() {
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 0));
+        let operator = BreakContinue::new(loc);
+        assert_eq!(operator.get_file_id(), fid);
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/literal.rs
+++ b/third_party/move/tools/move-mutator/src/operators/literal.rs
@@ -5,9 +5,11 @@ use crate::operators::{
     MOVE_ZERO_U16, MOVE_ZERO_U256, MOVE_ZERO_U32, MOVE_ZERO_U64, MOVE_ZERO_U8,
 };
 use crate::report::{Mutation, Range};
-use move_command_line_common::files::FileHash;
-use move_compiler::expansion::ast;
-use move_compiler::expansion::ast::Value_;
+use codespan::FileId;
+use move_model::ast::Value;
+use move_model::model::Loc;
+use move_model::ty::{PrimitiveType, Type};
+use num_traits::cast::ToPrimitive;
 use std::fmt;
 use std::fmt::Debug;
 
@@ -17,80 +19,112 @@ pub const OPERATOR_NAME: &str = "literal_replacement";
 /// Replaces literal statements with other ones but withing the same type.
 #[derive(Debug, Clone)]
 pub struct Literal {
-    operation: ast::Value,
+    operation: Value,
+    optype: Type,
+    loc: Loc,
 }
 
 impl Literal {
     /// Creates a new instance of the literal mutation operator.
     #[must_use]
-    pub fn new(operation: ast::Value) -> Self {
-        Self { operation }
+    pub fn new(operation: Value, optype: Type, loc: Loc) -> Self {
+        Self {
+            operation,
+            optype,
+            loc,
+        }
     }
 }
 
 impl MutationOperator for Literal {
     fn apply(&self, source: &str) -> Vec<MutantInfo> {
-        let start = self.operation.loc.start() as usize;
-        let end = self.operation.loc.end() as usize;
+        let start = self.loc.span().start().to_usize();
+        let end = self.loc.span().end().to_usize();
         let cur_op = &source[start..end];
 
         // Group of literal statements for possible Value types.
-        let ops: Vec<String> = match &self.operation.value {
-            Value_::Address(_addr) => {
+        let ops: Vec<String> = match &self.optype {
+            Type::Primitive(PrimitiveType::Address) => {
                 vec![MOVE_ADDR_ZERO.to_owned(), MOVE_ADDR_MAX.to_owned()]
             },
-            Value_::Bool(_bool_val) => {
+            Type::Primitive(PrimitiveType::Bool) => {
                 vec![MOVE_TRUE.to_owned(), MOVE_FALSE.to_owned()]
             },
-            Value_::Bytearray(_bytearray) => {
-                vec!["b\"121112\"".to_owned()]
+            Type::Primitive(PrimitiveType::U8) => {
+                if let Value::Number(bigint) = &self.operation {
+                    let u8_val = bigint.to_u8().expect("Invalid u8 value");
+
+                    vec![
+                        MOVE_ZERO_U8.to_owned(),
+                        MOVE_MAX_U8.to_owned(),
+                        u8_val.saturating_add(1).to_string(),
+                        u8_val.saturating_sub(1).to_string(),
+                    ]
+                } else {
+                    vec![]
+                }
             },
-            Value_::U8(u8_val) => {
-                vec![
-                    MOVE_ZERO_U8.to_owned(),
-                    MOVE_MAX_U8.to_owned(),
-                    u8_val.saturating_add(1).to_string(),
-                    u8_val.saturating_sub(1).to_string(),
-                ]
+            Type::Primitive(PrimitiveType::U16) => {
+                if let Value::Number(bigint) = &self.operation {
+                    let u16_val = bigint.to_u16().expect("Invalid u16 value");
+
+                    vec![
+                        MOVE_ZERO_U16.to_owned(),
+                        MOVE_MAX_U16.to_owned(),
+                        u16_val.saturating_add(1).to_string(),
+                        u16_val.saturating_sub(1).to_string(),
+                    ]
+                } else {
+                    vec![]
+                }
             },
-            Value_::U16(u16_val) => {
-                vec![
-                    MOVE_ZERO_U16.to_owned(),
-                    MOVE_MAX_U16.to_owned(),
-                    u16_val.saturating_add(1).to_string(),
-                    u16_val.saturating_sub(1).to_string(),
-                ]
+            Type::Primitive(PrimitiveType::U32) => {
+                if let Value::Number(bigint) = &self.operation {
+                    let u32_val = bigint.to_u32().expect("Invalid u32 value");
+
+                    vec![
+                        MOVE_ZERO_U32.to_owned(),
+                        MOVE_MAX_U32.to_owned(),
+                        u32_val.saturating_add(1).to_string(),
+                        u32_val.saturating_sub(1).to_string(),
+                    ]
+                } else {
+                    vec![]
+                }
             },
-            Value_::U32(u32_val) => {
-                vec![
-                    MOVE_ZERO_U32.to_owned(),
-                    MOVE_MAX_U32.to_owned(),
-                    u32_val.saturating_add(1).to_string(),
-                    u32_val.saturating_sub(1).to_string(),
-                ]
+            Type::Primitive(PrimitiveType::U64) => {
+                if let Value::Number(bigint) = &self.operation {
+                    let u64_val = bigint.to_u64().expect("Invalid u64 value");
+                    vec![
+                        MOVE_ZERO_U64.to_owned(),
+                        MOVE_MAX_U64.to_owned(),
+                        u64_val.saturating_add(1).to_string(),
+                        u64_val.saturating_sub(1).to_string(),
+                    ]
+                } else {
+                    vec![]
+                }
             },
-            Value_::U64(u64_val) => {
-                vec![
-                    MOVE_ZERO_U64.to_owned(),
-                    MOVE_MAX_U64.to_owned(),
-                    u64_val.saturating_add(1).to_string(),
-                    u64_val.saturating_sub(1).to_string(),
-                ]
+            Type::Primitive(PrimitiveType::U128) => {
+                if let Value::Number(bigint) = &self.operation {
+                    let u128_val = bigint.to_u128().expect("Invalid u128 value");
+                    vec![
+                        MOVE_ZERO_U128.to_owned(),
+                        MOVE_MAX_U128.to_owned(),
+                        u128_val.saturating_add(1).to_string(),
+                        u128_val.saturating_sub(1).to_string(),
+                    ]
+                } else {
+                    vec![]
+                }
             },
-            Value_::U128(u128_val) => {
-                vec![
-                    MOVE_ZERO_U128.to_owned(),
-                    MOVE_MAX_U128.to_owned(),
-                    u128_val.saturating_add(1).to_string(),
-                    u128_val.saturating_sub(1).to_string(),
-                ]
-            },
-            Value_::U256(_u256_val) => {
+            Type::Primitive(PrimitiveType::U256) => {
                 vec![MOVE_ZERO_U256.to_owned(), MOVE_MAX_U256.to_owned()]
             },
-            Value_::InferredNum(_inferred_num) => {
+            Type::Primitive(PrimitiveType::Num) => {
                 vec![MOVE_ZERO.to_owned(), MOVE_MAX_INFERRED_NUM.to_owned()]
             },
+            _ => vec![],
         };
 
         ops.into_iter()
@@ -111,8 +145,8 @@ impl MutationOperator for Literal {
             .collect()
     }
 
-    fn get_file_hash(&self) -> FileHash {
-        self.operation.loc.file_hash()
+    fn get_file_id(&self) -> FileId {
+        self.loc.file_id()
     }
 
     fn name(&self) -> String {
@@ -124,11 +158,11 @@ impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "LiteralOperator({:?}, location: file hash: {}, index start: {}, index stop: {})",
-            self.operation.value,
-            self.operation.loc.file_hash(),
-            self.operation.loc.start(),
-            self.operation.loc.end()
+            "LiteralOperator({:?}, location: file id: {:?}, index start: {}, index stop: {})",
+            self.operation,
+            self.loc.file_id(),
+            self.loc.span().start(),
+            self.loc.span().end()
         )
     }
 }
@@ -136,18 +170,19 @@ impl fmt::Display for Literal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use move_command_line_common::files::FileHash;
-    use move_compiler::expansion::ast::{Value, Value_};
-    use move_ir_types::location::Loc;
+    use codespan::Files;
 
     #[test]
     fn test_apply_u8() {
-        let loc = Loc::new(FileHash::new(""), 0, 2);
-        let val = Value {
-            value: Value_::U8(51),
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 2));
+
+        let operator = Literal::new(
+            Value::Number(51.into()),
+            Type::Primitive(PrimitiveType::U8),
             loc,
-        };
-        let operator = Literal::new(val);
+        );
         let source = "51";
         let expected = vec![MOVE_ZERO_U8, MOVE_MAX_U8, "52", "50"];
         let result = operator.apply(source);
@@ -159,12 +194,15 @@ mod tests {
 
     #[test]
     fn test_apply_u16() {
-        let loc = Loc::new(FileHash::new(""), 0, 3);
-        let val = Value {
-            value: Value_::U16(963),
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 3));
+
+        let operator = Literal::new(
+            Value::Number(963.into()),
+            Type::Primitive(PrimitiveType::U16),
             loc,
-        };
-        let operator = Literal::new(val);
+        );
         let source = "963";
         let expected = vec![MOVE_ZERO_U16, MOVE_MAX_U16, "964", "962"];
         let result = operator.apply(source);
@@ -176,12 +214,15 @@ mod tests {
 
     #[test]
     fn test_apply_u32() {
-        let loc = Loc::new(FileHash::new(""), 0, 7);
-        let val = Value {
-            value: Value_::U32(1000963),
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 7));
+
+        let operator = Literal::new(
+            Value::Number(1000963.into()),
+            Type::Primitive(PrimitiveType::U32),
             loc,
-        };
-        let operator = Literal::new(val);
+        );
         let source = "1000963";
         let expected = vec![MOVE_ZERO_U32, MOVE_MAX_U32, "1000964", "1000962"];
         let result = operator.apply(source);
@@ -193,12 +234,15 @@ mod tests {
 
     #[test]
     fn test_apply_u64() {
-        let loc = Loc::new(FileHash::new(""), 0, 12);
-        let val = Value {
-            value: Value_::U64(963251000963),
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 12));
+
+        let operator = Literal::new(
+            Value::Number(963251000963u128.into()),
+            Type::Primitive(PrimitiveType::U64),
             loc,
-        };
-        let operator = Literal::new(val);
+        );
         let source = "963251000963";
         let expected = vec![MOVE_ZERO_U64, MOVE_MAX_U64, "963251000964", "963251000962"];
         let result = operator.apply(source);
@@ -210,12 +254,15 @@ mod tests {
 
     #[test]
     fn test_apply_u128() {
-        let loc = Loc::new(FileHash::new(""), 0, 15);
-        let val = Value {
-            value: Value_::U128(123963251000963),
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 15));
+
+        let operator = Literal::new(
+            Value::Number(123963251000963u128.into()),
+            Type::Primitive(PrimitiveType::U128),
             loc,
-        };
-        let operator = Literal::new(val);
+        );
         let source = "123963251000963";
         let expected = vec![
             MOVE_ZERO_U128,
@@ -232,12 +279,11 @@ mod tests {
 
     #[test]
     fn test_apply_bool() {
-        let loc = Loc::new(FileHash::new(""), 0, 4);
-        let val = Value {
-            value: Value_::Bool(true),
-            loc,
-        };
-        let operator = Literal::new(val);
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 4));
+
+        let operator = Literal::new(Value::Bool(true), Type::Primitive(PrimitiveType::Bool), loc);
         let source = MOVE_TRUE;
         let expected = vec![MOVE_FALSE];
         let result = operator.apply(source);
@@ -248,13 +294,12 @@ mod tests {
     }
 
     #[test]
-    fn test_get_file_hash() {
-        let loc = Loc::new(FileHash::new(""), 0, 0);
-        let val = Value {
-            value: Value_::U8(99),
-            loc,
-        };
-        let operator = Literal::new(val);
-        assert_eq!(operator.get_file_hash(), FileHash::new(""));
+    fn test_get_file_id() {
+        let mut files = Files::new();
+        let fid = files.add("test", "test");
+        let loc = Loc::new(fid, codespan::Span::new(0, 4));
+
+        let operator = Literal::new(Value::Bool(true), Type::Primitive(PrimitiveType::Bool), loc);
+        assert_eq!(operator.get_file_id(), fid);
     }
 }

--- a/third_party/move/tools/move-mutator/src/operators/mod.rs
+++ b/third_party/move/tools/move-mutator/src/operators/mod.rs
@@ -1,5 +1,9 @@
+use move_model::ast::Exp;
+use move_model::model::Loc;
+
 pub(crate) mod binary;
 pub(crate) mod binary_swap;
+
 pub(crate) mod break_continue;
 pub(crate) mod delete_stmt;
 pub(crate) mod ifelse;
@@ -31,3 +35,17 @@ pub(crate) const MOVE_MAX_INFERRED_NUM: &str =
 pub(crate) const MOVE_ADDR_ZERO: &str = "0x0";
 pub(crate) const MOVE_ADDR_MAX: &str =
     "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+
+#[derive(Debug, Clone)]
+pub struct ExpLoc {
+    pub exp: Exp,
+    pub loc: Loc,
+}
+
+impl ExpLoc {
+    /// Creates a new expression with location.
+    #[cfg(test)]
+    pub fn new(exp: Exp, loc: Loc) -> Self {
+        Self { exp, loc }
+    }
+}

--- a/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/Sub.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/Sub.move
@@ -1,4 +1,4 @@
-module Test::Sub {
+module 0xCAFE::Sub {
     fun sub(x: u128, y: u128): u128 {
         let sub_r = x - y;
         spec {

--- a/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/conditional.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/conditional.move
@@ -1,4 +1,4 @@
-module Test::Cond {
+module 0xCAFE::Cond {
     fun main() {
         let a = true;
         if (a) {

--- a/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/move_to.move
+++ b/third_party/move/tools/move-mutator/tests/move-assets/file_without_package/move_to.move
@@ -1,4 +1,4 @@
-module 0x2::Collection {
+module 0xCAFE::Collection {
     struct Item has store {}
 
     struct Collection has key {


### PR DESCRIPTION
### Description

This PR changes compiler backend as well as introdues `move-model` AST to the project.

All mutation operators have been updated.

### Test Plan
All existing unit and integration tests.
